### PR TITLE
update points page for 2026

### DIFF
--- a/content/points/2025.md
+++ b/content/points/2025.md
@@ -1,0 +1,7 @@
+---
+title: "Points - 2025 Season"
+draft: false
+layout: list
+google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1679642755&single=true&output=csv"
+sub_title: "2025 Season"
+---

--- a/content/points/_index.md
+++ b/content/points/_index.md
@@ -2,6 +2,6 @@
 title: "Points"
 draft: false
 menu: "navbar"
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1679642755&single=true&output=csv"
-sub_title: "2025 Season"
+google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1224024426&single=true&output=csv"
+sub_title: "2026 Season"
 ---

--- a/layouts/points/list.html
+++ b/layouts/points/list.html
@@ -15,7 +15,8 @@
 
 
   <p class="mt-4 text-sm text-gray-700 lg:pr-32">
-    <a href="/points">2025</a> |
+    <a href="/points">2026</a> |
+    <a href="/points/2025">2025</a> |
     <a href="/points/2024">2024</a> |
     <a href="/points/2023">2023</a> |
     <a href="/points/2022">2022</a>


### PR DESCRIPTION
updating the website to include the 2026 points standings now that a tournament has taken place

1. point current landing page at the 2026 data
2. add sub-page for the 2025 data