### PR TITLE
Update redirect paths to Rules of Play version 1.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,12 +9,12 @@
 
 [[redirects]]
   from = "/rules"
-  to = "/documents/ILSA%20-%20Rules%20of%20Play%20-%201.1.pdf"
+  to = "/documents/ILSA%20-%20Rules%20of%20Play%20-%201.2.pdf"
   status = 302
 
 [[redirects]]
   from = "/howtoplay"
-  to = "/documents/ILSA%20-%20Rules%20of%20Play%20-%201.1.pdf"
+  to = "/documents/ILSA%20-%20Rules%20of%20Play%20-%201.2.pdf"
   status = 302
   # now points to full rules, later to lightweight rules
 


### PR DESCRIPTION
Update rules short links to point to new rules document (instead of 404)