### PR TITLE
refactor(points): migrate data from Google Sheets CSV to YAML files

### DIFF
--- a/content/points/2022.md
+++ b/content/points/2022.md
@@ -2,6 +2,6 @@
 title: "Points - 2022 Season"
 draft: false
 layout: list
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=0&single=true&output=csv"
 sub_title: "2022 Season"
+year: 2022
 ---

--- a/content/points/2023.md
+++ b/content/points/2023.md
@@ -2,6 +2,6 @@
 title: "Points - 2023 Season"
 draft: false
 layout: list
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1700357413&single=true&output=csv"
 sub_title: "2023 Season"
+year: 2023
 ---

--- a/content/points/2024.md
+++ b/content/points/2024.md
@@ -2,6 +2,6 @@
 title: "Points - 2024 Season"
 draft: false
 layout: list
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=151826142&single=true&output=csv"
 sub_title: "2024 Season"
+year: 2024
 ---

--- a/content/points/2025.md
+++ b/content/points/2025.md
@@ -2,6 +2,6 @@
 title: "Points - 2025 Season"
 draft: false
 layout: list
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1679642755&single=true&output=csv"
 sub_title: "2025 Season"
+year: 2025
 ---

--- a/content/points/_index.md
+++ b/content/points/_index.md
@@ -2,6 +2,6 @@
 title: "Points"
 draft: false
 menu: "navbar"
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1224024426&single=true&output=csv"
 sub_title: "2026 Season"
+year: 2026
 ---

--- a/content/points/alltime.md
+++ b/content/points/alltime.md
@@ -2,6 +2,5 @@
 title: "Points - All-Time"
 draft: false
 layout: list
-google_doc: "https://docs.google.com/spreadsheets/d/e/2PACX-1vScLQRh8JxhhfkZp1To8ut2KvdS0yj9Ge5dQJeXxtPRp4YzehEWxE3ft4U3wT3JGLn09T14DzBDLXQL/pub?gid=1959389270&single=true&output=csv"
 sub_title: "All-Time"
 ---

--- a/data/results/2022-chicago-il-national-tournament.yaml
+++ b/data/results/2022-chicago-il-national-tournament.yaml
@@ -1,0 +1,170 @@
+event: "Chicago, IL National Tournament"
+category: national
+year: 2022
+results:
+  - player: "Michael Brady"
+    points: 9
+  - player: "Mathew Savill"
+    points: 8
+  - player: "James Kessler"
+    points: 8
+  - player: "Karson Bodnovich"
+    points: 7
+  - player: "Joe Brennan"
+    points: 7
+  - player: "Aaron Politsky"
+    points: 6
+  - player: "Thanh Seybold"
+    points: 6
+  - player: "Robert O'mahoney"
+    points: 5
+  - player: "Jeff Ziev"
+    points: 4
+  - player: "Missy Kayko"
+    points: 4
+  - player: "Jerry Read"
+    points: 3
+  - player: "Roy Wicklund"
+    points: 3
+  - player: "Adam Rahmel"
+    points: 2
+  - player: "Maxwell Julius"
+    points: 2
+  - player: "Samuel Dewey"
+    points: 1
+  - player: "Tyler Berry"
+    points: 1
+  - player: "Steven Perry"
+    points: 1
+  - player: "Dustin Kozal"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Joshua D Garrett"
+    points: 1
+  - player: "Paul Assad"
+    points: 1
+  - player: "Michael A Dritto"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Christine Page"
+    points: 1
+  - player: "Jordan Halpern"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "John Reavey"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Christy Gregory"
+    points: 1
+  - player: "David Berman"
+    points: 1
+  - player: "James Parizek"
+    points: 1
+  - player: "Neal Hamer"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Craig Kelbus"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "Josh Brown"
+    points: 1
+  - player: "Kristina Walter"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Bobby Peterson"
+    points: 1
+  - player: "Brandon V"
+    points: 1
+  - player: "Charles Polette"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Josh Dulabaum"
+    points: 1
+  - player: "Susan R"
+    points: 1
+  - player: "Andy Norton"
+    points: 1
+  - player: "August Etsch"
+    points: 1
+  - player: "Bonnie Balmos"
+    points: 1
+  - player: "Cortney Norton"
+    points: 1
+  - player: "Dillon Stevens"
+    points: 1
+  - player: "Douglas Burger"
+    points: 1
+  - player: "Eric Papa"
+    points: 1
+  - player: "Erik Carrier"
+    points: 1
+  - player: "Erik Soderstrom"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Ian Ainley"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Jonathan Hennessy"
+    points: 1
+  - player: "Jordan Gutierrez"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Justin Stewart"
+    points: 1
+  - player: "Katie Woodward"
+    points: 1
+  - player: "Kevin Vlcek"
+    points: 1
+  - player: "Kevin Wickman"
+    points: 1
+  - player: "Kristen Haut"
+    points: 1
+  - player: "Mark Goheen"
+    points: 1
+  - player: "Matthew Miller"
+    points: 1
+  - player: "Mickey Novak"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Sarah Mroue"
+    points: 1
+  - player: "Sarah Osako"
+    points: 1
+  - player: "Stephanie Swain"
+    points: 1
+  - player: "Terence Young"
+    points: 1
+  - player: "Thomas Gustafson"
+    points: 1
+  - player: "Thomas Rocca"
+    points: 1
+  - player: "Timothy Hosty"
+    points: 1

--- a/data/results/2022-fall-2022-league.yaml
+++ b/data/results/2022-fall-2022-league.yaml
@@ -1,0 +1,26 @@
+event: "Fall 2022 League"
+category: league
+year: 2022
+results:
+  - player: "Mark Malatt"
+    points: 10
+  - player: "Robert O'mahoney"
+    points: 8
+  - player: "Mathew Savill"
+    points: 6
+  - player: "John Reavey"
+    points: 5
+  - player: "Lauren Seesel"
+    points: 3
+  - player: "Derek Falk"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Christy Gregory"
+    points: 2
+  - player: "Craig Kelbus"
+    points: 2
+  - player: "Natalie Gabrenya"
+    points: 2
+  - player: "Jaime Etsch"
+    points: 1

--- a/data/results/2022-hendersonville-nc-national-tournament.yaml
+++ b/data/results/2022-hendersonville-nc-national-tournament.yaml
@@ -1,0 +1,22 @@
+event: "Hendersonville, NC National Tournament"
+category: national
+year: 2022
+results:
+  - player: "Aaron Politsky"
+    points: 6
+  - player: "Christine Page"
+    points: 5
+  - player: "Trevor Hess"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Jason Hiquet"
+    points: 2
+  - player: "Lauren Seesel"
+    points: 2
+  - player: "Maggie Jones"
+    points: 2
+  - player: "Doug Moring"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1

--- a/data/results/2022-jingle-biscuits.yaml
+++ b/data/results/2022-jingle-biscuits.yaml
@@ -1,0 +1,36 @@
+event: "Jingle Biscuits"
+category: ilsa
+year: 2022
+results:
+  - player: "Samuel Dewey"
+    points: 10
+  - player: "Steven Perry"
+    points: 10
+  - player: "Dustin Kozal"
+    points: 8
+  - player: "Chris Abernathy"
+    points: 8
+  - player: "Michael A Dritto"
+    points: 6
+  - player: "Connor Morehouse"
+    points: 6
+  - player: "Teddy Wachholz"
+    points: 5
+  - player: "Sammy Wachholz"
+    points: 5
+  - player: "Jordon Novak"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Dan Love"
+    points: 2
+  - player: "Anna Balchunas"
+    points: 2
+  - player: "Nicholas Goldman"
+    points: 2
+  - player: "Andrew Gonzales"
+    points: 2
+  - player: "James Devine"
+    points: 2
+  - player: "Voltaire Alanguilan"
+    points: 2

--- a/data/results/2022-lakeland-fl-national-tournament.yaml
+++ b/data/results/2022-lakeland-fl-national-tournament.yaml
@@ -1,0 +1,6 @@
+event: "Lakeland, FL National Tournament"
+category: national
+year: 2022
+results:
+  - player: "Christine Page"
+    points: 1

--- a/data/results/2022-lakeside-oh-national-tournament.yaml
+++ b/data/results/2022-lakeside-oh-national-tournament.yaml
@@ -1,0 +1,24 @@
+event: "Lakeside, OH National Tournament"
+category: national
+year: 2022
+results:
+  - player: "Jeff Ziev"
+    points: 5
+  - player: "Doug Moring"
+    points: 4
+  - player: "Trevor Hess"
+    points: 3
+  - player: "Abby Manville"
+    points: 2
+  - player: "Al Manville"
+    points: 2
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "Paul Assad"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Christine Page"
+    points: 1

--- a/data/results/2022-mirror-lake-championship-tournament.yaml
+++ b/data/results/2022-mirror-lake-championship-tournament.yaml
@@ -1,0 +1,62 @@
+event: "Mirror Lake Championship Tournament"
+category: championship
+year: 2022
+results:
+  - player: "Paul Assad"
+    points: 8
+  - player: "Missy Kayko"
+    points: 4
+  - player: "Dan Love"
+    points: 2
+  - player: "Samuel Dewey"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "Tyler Berry"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Derek Falk"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "John Reavey"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Kate Fitzgerald"
+    points: 1
+  - player: "Christy Gregory"
+    points: 1
+  - player: "David Berman"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Brandon V"
+    points: 1
+  - player: "Charles Polette"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Josh Dulabaum"
+    points: 1
+  - player: "Susan R"
+    points: 1
+  - player: "Emily Ellsworth"
+    points: 1
+  - player: "Michelle DiMaggio"
+    points: 1

--- a/data/results/2022-mirror-lake-championship-tournament.yaml
+++ b/data/results/2022-mirror-lake-championship-tournament.yaml
@@ -1,5 +1,5 @@
 event: "Mirror Lake Championship Tournament"
-category: championship
+category: other
 year: 2022
 results:
   - player: "Paul Assad"

--- a/data/results/2022-spring-2022-league.yaml
+++ b/data/results/2022-spring-2022-league.yaml
@@ -1,0 +1,26 @@
+event: "Spring 2022 League"
+category: league
+year: 2022
+results:
+  - player: "Robert O'mahoney"
+    points: 10
+  - player: "Samuel Dewey"
+    points: 8
+  - player: "Aaron Politsky"
+    points: 6
+  - player: "Mathew Savill"
+    points: 5
+  - player: "Doug Moring"
+    points: 3
+  - player: "James Kessler"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Kristina Walter"
+    points: 2
+  - player: "David Berman"
+    points: 1

--- a/data/results/2022-st-peterick-s-tournament.yaml
+++ b/data/results/2022-st-peterick-s-tournament.yaml
@@ -1,0 +1,30 @@
+event: "St Peterick's Tournament"
+category: ilsa
+year: 2022
+results:
+  - player: "Tyler Berry"
+    points: 7
+  - player: "Jordan Halpern"
+    points: 7
+  - player: "Maxwell Julius"
+    points: 5
+  - player: "Sara Helwink"
+    points: 5
+  - player: "Dustin Kozal"
+    points: 3
+  - player: "James Parizek"
+    points: 3
+  - player: "Teddy Wachholz"
+    points: 2
+  - player: "Josh Brown"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "Bobby Peterson"
+    points: 1
+  - player: "Tyler Hienkel"
+    points: 1

--- a/data/results/2022-summer-2022-league.yaml
+++ b/data/results/2022-summer-2022-league.yaml
@@ -1,0 +1,26 @@
+event: "Summer 2022 League"
+category: league
+year: 2022
+results:
+  - player: "Samuel Dewey"
+    points: 10
+  - player: "Derek Falk"
+    points: 8
+  - player: "Trevor Hess"
+    points: 6
+  - player: "Tyler Berry"
+    points: 5
+  - player: "Jason Hiquet"
+    points: 3
+  - player: "Steven Perry"
+    points: 2
+  - player: "Joe Brennan"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Jordon Novak"
+    points: 2
+  - player: "Maxwell Julius"
+    points: 1

--- a/data/results/2022-tangsgiving.yaml
+++ b/data/results/2022-tangsgiving.yaml
@@ -1,0 +1,20 @@
+event: "Tangsgiving"
+category: ilsa
+year: 2022
+results:
+  - player: "Mathew Savill"
+    points: 10
+  - player: "Joshua D Garrett"
+    points: 8
+  - player: "Adam Rahmel"
+    points: 6
+  - player: "Kate Fitzgerald"
+    points: 5
+  - player: "Kevin Reedy"
+    points: 4
+  - player: "Brian Sheehan"
+    points: 3
+  - player: "Michael A Dritto"
+    points: 2
+  - player: "Mark Malatt"
+    points: 1

--- a/data/results/2022-tangsgiving.yaml
+++ b/data/results/2022-tangsgiving.yaml
@@ -1,5 +1,5 @@
 event: "Tangsgiving"
-category: ilsa
+category: other
 year: 2022
 results:
   - player: "Mathew Savill"

--- a/data/results/2022-ten-d-off-tournament.yaml
+++ b/data/results/2022-ten-d-off-tournament.yaml
@@ -1,0 +1,36 @@
+event: "Ten(d) Off Tournament"
+category: ilsa
+year: 2022
+results:
+  - player: "Aaron Politsky"
+    points: 7
+  - player: "Kaleigh Velasquez"
+    points: 7
+  - player: "Karson Bodnovich"
+    points: 5
+  - player: "Sean Reddington"
+    points: 5
+  - player: "Neal Hamer"
+    points: 3
+  - player: "Mike Doherty"
+    points: 3
+  - player: "Adam Rahmel"
+    points: 2
+  - player: "Jenna Blanton"
+    points: 2
+  - player: "Joshua D Garrett"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "David Berman"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "Nicholas Goldman"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Kiernan Ambrose"
+    points: 1
+  - player: "Luke Wesolowski"
+    points: 1

--- a/data/results/2023-chicago-il-national.yaml
+++ b/data/results/2023-chicago-il-national.yaml
@@ -1,0 +1,176 @@
+event: "Chicago, IL National"
+category: national
+year: 2023
+results:
+  - player: "Samuel Dewey"
+    points: 9
+  - player: "Steven Perry"
+    points: 9
+  - player: "Tyler Berry"
+    points: 8
+  - player: "Justin Stewart"
+    points: 8
+  - player: "John Reavey"
+    points: 7
+  - player: "David Berman"
+    points: 7
+  - player: "Mark Malatt"
+    points: 6
+  - player: "Kate Fitzgerald"
+    points: 6
+  - player: "Michael Brady"
+    points: 5
+  - player: "Mike Dunlap"
+    points: 5
+  - player: "Sammy Wachholz"
+    points: 3
+  - player: "Kristina Walter"
+    points: 3
+  - player: "Adam Jamrozy"
+    points: 2
+  - player: "Andrew Collier"
+    points: 2
+  - player: "Michael A Dritto"
+    points: 1
+  - player: "Robert O'mahoney"
+    points: 1
+  - player: "Paul Assad"
+    points: 1
+  - player: "Connor Morehouse"
+    points: 1
+  - player: "Maxwell Julius"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Christine Page"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Eric R Koch"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Adam Rahmel"
+    points: 1
+  - player: "James Kessler"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Joshua D Garrett"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Dustin Kozal"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Kim Marek"
+    points: 1
+  - player: "Brandon V"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Kiernan Ambrose"
+    points: 1
+  - player: "Susan R"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "Andy Norton"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Ashly Powley"
+    points: 1
+  - player: "Brandon Queen"
+    points: 1
+  - player: "Chris Abernathy"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Mathew Savill"
+    points: 1
+  - player: "Mickey Novak"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Kevin Wickman"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1
+  - player: "Matt Nakano"
+    points: 1
+  - player: "Matthew Miller"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Thomas M. Rocca"
+    points: 1
+  - player: "August Etsch"
+    points: 1
+  - player: "Cortney Norton"
+    points: 1
+  - player: "David A Bahr"
+    points: 1
+  - player: "David Chester"
+    points: 1
+  - player: "David Heeley"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "Eric Nuebling"
+    points: 1
+  - player: "Erik Soderstrom"
+    points: 1
+  - player: "Jaime Etsch"
+    points: 1
+  - player: "Jeffrey Behrens"
+    points: 1
+  - player: "Jerry Read"
+    points: 1
+  - player: "Jessica Badger"
+    points: 1
+  - player: "John Shaw"
+    points: 1
+  - player: "Katie Woodward"
+    points: 1
+  - player: "Kevin Vlcek"
+    points: 1
+  - player: "Lizzy Tiritilli"
+    points: 1
+  - player: "Monique Costello"
+    points: 1
+  - player: "Neal Hamer"
+    points: 1
+  - player: "Roy Wicklund"
+    points: 1
+  - player: "Thomas Elwood"
+    points: 1
+  - player: "Timothy Hosty"
+    points: 1
+  - player: "Voltaire Alanguilan"
+    points: 1

--- a/data/results/2023-clearwater-fl-national-tournament.yaml
+++ b/data/results/2023-clearwater-fl-national-tournament.yaml
@@ -1,0 +1,22 @@
+event: "Clearwater, FL National Tournament"
+category: national
+year: 2023
+results:
+  - player: "Karson Bodnovich"
+    points: 3
+  - player: "Joe Brennan"
+    points: 3
+  - player: "Christine Page"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Josh Dulabaum"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Stephanie Swain"
+    points: 1

--- a/data/results/2023-fall-2023-league.yaml
+++ b/data/results/2023-fall-2023-league.yaml
@@ -1,0 +1,20 @@
+event: "Fall 2023 League"
+category: league
+year: 2023
+results:
+  - player: "Mark Malatt"
+    points: 10
+  - player: "Tyler Berry"
+    points: 8
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Joshua D Garrett"
+    points: 5
+  - player: "Maxwell Julius"
+    points: 2
+  - player: "Dustin Kozal"
+    points: 2
+  - player: "Brian O'Connell"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2

--- a/data/results/2023-hendersonville-nc-national-tournaments.yaml
+++ b/data/results/2023-hendersonville-nc-national-tournaments.yaml
@@ -1,0 +1,12 @@
+event: "Hendersonville, NC National Tournaments"
+category: national
+year: 2023
+results:
+  - player: "Christine Page"
+    points: 4
+  - player: "Trevor Hess"
+    points: 4
+  - player: "Doug Moring"
+    points: 1
+  - player: "Alan Rosetti"
+    points: 1

--- a/data/results/2023-lakeside-oh-national-tournaments.yaml
+++ b/data/results/2023-lakeside-oh-national-tournaments.yaml
@@ -1,0 +1,38 @@
+event: "Lakeside, OH National Tournaments"
+category: national
+year: 2023
+results:
+  - player: "Paul Assad"
+    points: 9
+  - player: "Abby Manville"
+    points: 8
+  - player: "Lauren Seesel"
+    points: 7
+  - player: "Christine Page"
+    points: 4
+  - player: "Amelia Burger"
+    points: 3
+  - player: "Doug Moring"
+    points: 2
+  - player: "Al Manville"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1

--- a/data/results/2023-mirror-lake-championship-tournament.yaml
+++ b/data/results/2023-mirror-lake-championship-tournament.yaml
@@ -1,0 +1,116 @@
+event: "Mirror Lake Championship Tournament"
+category: championship
+year: 2023
+results:
+  - player: "Paul Assad"
+    points: 8
+  - player: "Missy Kayko"
+    points: 7
+  - player: "Josh Dulabaum"
+    points: 5
+  - player: "Michael A Dritto"
+    points: 1
+  - player: "Robert O'mahoney"
+    points: 1
+  - player: "Samuel Dewey"
+    points: 1
+  - player: "Connor Morehouse"
+    points: 1
+  - player: "Derek Falk"
+    points: 1
+  - player: "Maxwell Julius"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Kate Fitzgerald"
+    points: 1
+  - player: "Steven Perry"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "David Berman"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Michael Brady"
+    points: 1
+  - player: "Adam Rahmel"
+    points: 1
+  - player: "James Kessler"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Natalie Gabrenya"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "Brandon V"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Kristina Walter"
+    points: 1
+  - player: "Susan R"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "Alan Rosetti"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Brandon Queen"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Adam Fratino"
+    points: 1
+  - player: "Douglas Burger"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Ian Ainley"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Kevin Wickman"
+    points: 1
+  - player: "Mark Goheen"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Ashley De La Rosa"
+    points: 1
+  - player: "Craig Kelbus"
+    points: 1
+  - player: "Emily Ellsworth"
+    points: 1
+  - player: "Emma Kehm"
+    points: 1
+  - player: "Michelle DiMaggio"
+    points: 1
+  - player: "Scott Montgomery"
+    points: 1

--- a/data/results/2023-mirror-lake-championship-tournament.yaml
+++ b/data/results/2023-mirror-lake-championship-tournament.yaml
@@ -1,5 +1,5 @@
 event: "Mirror Lake Championship Tournament"
-category: championship
+category: other
 year: 2023
 results:
   - player: "Paul Assad"

--- a/data/results/2023-one-tang-at-a-time-tournament.yaml
+++ b/data/results/2023-one-tang-at-a-time-tournament.yaml
@@ -1,0 +1,26 @@
+event: "One Tang at a Time Tournament"
+category: ilsa
+year: 2023
+results:
+  - player: "Maxwell Julius"
+    points: 4
+  - player: "Adam Rahmel"
+    points: 4
+  - player: "James Kessler"
+    points: 4
+  - player: "Kim Marek"
+    points: 4
+  - player: "Dustin Kozal"
+    points: 2
+  - player: "Brandon V"
+    points: 2
+  - player: "Susan R"
+    points: 2
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Eric R Koch"
+    points: 1
+  - player: "Matt Nakano"
+    points: 1
+  - player: "Samuel Pare"
+    points: 1

--- a/data/results/2023-san-benito-tx-national-tournament.yaml
+++ b/data/results/2023-san-benito-tx-national-tournament.yaml
@@ -1,0 +1,6 @@
+event: "San Benito, TX National Tournament"
+category: national
+year: 2023
+results:
+  - player: "Doug Moring"
+    points: 1

--- a/data/results/2023-spring-2023-league.yaml
+++ b/data/results/2023-spring-2023-league.yaml
@@ -1,0 +1,26 @@
+event: "Spring 2023 League"
+category: league
+year: 2023
+results:
+  - player: "Michael A Dritto"
+    points: 10
+  - player: "Connor Morehouse"
+    points: 8
+  - player: "Jason Hiquet"
+    points: 6
+  - player: "Kevin Reedy"
+    points: 5
+  - player: "John Allen"
+    points: 3
+  - player: "Maxwell Julius"
+    points: 2
+  - player: "Christy Gregory"
+    points: 2
+  - player: "Andy Norton"
+    points: 2
+  - player: "Chris Abernathy"
+    points: 2
+  - player: "James Parizek"
+    points: 2
+  - player: "Juliana Kaye"
+    points: 1

--- a/data/results/2023-st-pete-fl-national-tournament.yaml
+++ b/data/results/2023-st-pete-fl-national-tournament.yaml
@@ -1,0 +1,80 @@
+event: "St Pete, FL National Tournament"
+category: national
+year: 2023
+results:
+  - player: "Karson Bodnovich"
+    points: 3
+  - player: "Christy Gregory"
+    points: 3
+  - player: "Paul Assad"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Josh Dulabaum"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Michael Brady"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Mike Dunlap"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Alan Rosetti"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Brandon Queen"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Adam Fratino"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Douglas Burger"
+    points: 1
+  - player: "Ian Ainley"
+    points: 1
+  - player: "Mark Goheen"
+    points: 1
+  - player: "Matthew Miller"
+    points: 1
+  - player: "Stephanie Swain"
+    points: 1
+  - player: "Thomas M. Rocca"
+    points: 1
+  - player: "Eric Papa"
+    points: 1

--- a/data/results/2023-tangsgiving.yaml
+++ b/data/results/2023-tangsgiving.yaml
@@ -1,0 +1,20 @@
+event: "Tangsgiving"
+category: ilsa
+year: 2023
+results:
+  - player: "Michael A Dritto"
+    points: 10
+  - player: "James Gallagher"
+    points: 8
+  - player: "Adam Jamrozy"
+    points: 6
+  - player: "Eric R Koch"
+    points: 5
+  - player: "Juliana Kaye"
+    points: 4
+  - player: "Derek Falk"
+    points: 3
+  - player: "Kate Fitzgerald"
+    points: 2
+  - player: "Jim Seesel"
+    points: 1

--- a/data/results/2023-tangsgiving.yaml
+++ b/data/results/2023-tangsgiving.yaml
@@ -1,5 +1,5 @@
 event: "Tangsgiving"
-category: ilsa
+category: other
 year: 2023
 results:
   - player: "Michael A Dritto"

--- a/data/results/2023-west-slide-story.yaml
+++ b/data/results/2023-west-slide-story.yaml
@@ -1,0 +1,32 @@
+event: "West Slide Story"
+category: ilsa
+year: 2023
+results:
+  - player: "Derek Falk"
+    points: 10
+  - player: "Philip A Beeler"
+    points: 10
+  - player: "Robert O'mahoney"
+    points: 8
+  - player: "Connor Morehouse"
+    points: 6
+  - player: "Bobby Peterson"
+    points: 6
+  - player: "John Reavey"
+    points: 5
+  - player: "Natalie Gabrenya"
+    points: 5
+  - player: "Justin Latta"
+    points: 2
+  - player: "John Allen"
+    points: 2
+  - player: "Ashly Powley"
+    points: 2
+  - player: "Mathew Savill"
+    points: 2
+  - player: "Andrew Seputis"
+    points: 2
+  - player: "Derek Slater"
+    points: 2
+  - player: "Julie Paris"
+    points: 2

--- a/data/results/2023-winter-2023-league.yaml
+++ b/data/results/2023-winter-2023-league.yaml
@@ -1,0 +1,26 @@
+event: "Winter 2023 League"
+category: league
+year: 2023
+results:
+  - player: "Samuel Dewey"
+    points: 10
+  - player: "Tyler Berry"
+    points: 8
+  - player: "Michael A Dritto"
+    points: 6
+  - player: "Robert O'mahoney"
+    points: 5
+  - player: "Kiernan Ambrose"
+    points: 3
+  - player: "Maxwell Julius"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Josh Petras"
+    points: 2
+  - player: "Mickey Novak"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Kate Fitzgerald"
+    points: 1

--- a/data/results/2024-brooklyn-ny-national.yaml
+++ b/data/results/2024-brooklyn-ny-national.yaml
@@ -1,0 +1,108 @@
+event: "Brooklyn, NY National"
+category: national
+year: 2024
+results:
+  - player: "Robert O'mahoney"
+    points: 9
+  - player: "Kim Marek"
+    points: 9
+  - player: "Eric Papa"
+    points: 8
+  - player: "James Gallagher"
+    points: 4
+  - player: "August Etsch"
+    points: 4
+  - player: "Joshua D Garrett"
+    points: 3
+  - player: "Diana Diaz"
+    points: 3
+  - player: "Teddy Wachholz"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Michael Brady"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Mark Malatt"
+    points: 1
+  - player: "John Windler"
+    points: 1
+  - player: "Michael A Dritto"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Mike Dunlap"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Christine Page"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Gabe Paul"
+    points: 1
+  - player: "John Allen"
+    points: 1
+  - player: "Clayton Taylor"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Derek Falk"
+    points: 1
+  - player: "Kate Fitzgerald"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Kristina Walter"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Michelle DiMaggio"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Carlie DeMelo"
+    points: 1
+  - player: "Christy Gregory"
+    points: 1
+  - player: "Emily Ellsworth"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Nicholas Goldman"
+    points: 1
+  - player: "Roy Wicklund"
+    points: 1
+  - player: "Natalie Gabrenya"
+    points: 1
+  - player: "Rebecca Mendoza"
+    points: 1
+  - player: "S Rosero"
+    points: 1
+  - player: "Samuel Dewey"
+    points: 1
+  - player: "Steven Perry"
+    points: 1
+  - player: "Katie Woodward"
+    points: 1
+  - player: "Tom Wittemann"
+    points: 1

--- a/data/results/2024-chicago-il-national.yaml
+++ b/data/results/2024-chicago-il-national.yaml
@@ -1,0 +1,180 @@
+event: "Chicago, IL National"
+category: national
+year: 2024
+results:
+  - player: "Michael Brady"
+    points: 9
+  - player: "Mike Dunlap"
+    points: 9
+  - player: "Tyler Berry"
+    points: 7
+  - player: "Dave Berman"
+    points: 7
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Kim Marek"
+    points: 6
+  - player: "Brian O'Connell"
+    points: 5
+  - player: "Kiernan Ambrose"
+    points: 5
+  - player: "Erik Windler"
+    points: 4
+  - player: "Gabe Paul"
+    points: 4
+  - player: "Craig Kelbus"
+    points: 3
+  - player: "Emma Kehm"
+    points: 3
+  - player: "Michael A Dritto"
+    points: 2
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Paul Assad"
+    points: 1
+  - player: "Sean Reddington"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Mark Malatt"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "Kevin Wickman"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "James Parizek"
+    points: 1
+  - player: "Fabiola Camacho"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Joshua D Garrett"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Adam Jamrozy"
+    points: 1
+  - player: "Andrew Collier"
+    points: 1
+  - player: "Neal Hamer"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "Tyler Janese"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "John Allen"
+    points: 1
+  - player: "Kristen Haut"
+    points: 1
+  - player: "Maxwell Julius"
+    points: 1
+  - player: "David Smith"
+    points: 1
+  - player: "Eric R Koch"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Spencer McNeil"
+    points: 1
+  - player: "Derek Falk"
+    points: 1
+  - player: "Kate Fitzgerald"
+    points: 1
+  - player: "Kristina Walter"
+    points: 1
+  - player: "Matt Nakano"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1
+  - player: "Carlie DeMelo"
+    points: 1
+  - player: "Christy Gregory"
+    points: 1
+  - player: "Emily Ellsworth"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Nicholas Goldman"
+    points: 1
+  - player: "Roy Wicklund"
+    points: 1
+  - player: "Andy Norton"
+    points: 1
+  - player: "Cortney Norton"
+    points: 1
+  - player: "Jillian Madden"
+    points: 1
+  - player: "Rebecca Mendoza"
+    points: 1
+  - player: "S Rosero"
+    points: 1
+  - player: "Samuel Dewey"
+    points: 1
+  - player: "Sarah Osako"
+    points: 1
+  - player: "Scott Montgomery"
+    points: 1
+  - player: "Steven Perry"
+    points: 1
+  - player: "Thomas Gustafson"
+    points: 1
+  - player: "Timothy Hosty"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1
+  - player: "Voltaire Alanguilan"
+    points: 1
+  - player: "Brad Uidl"
+    points: 1
+  - player: "Brandon V"
+    points: 1
+  - player: "Charles Mikell"
+    points: 1
+  - player: "Cody Uidl"
+    points: 1
+  - player: "Connor Morehouse"
+    points: 1
+  - player: "Eric Nuebling"
+    points: 1
+  - player: "Ian McKee"
+    points: 1
+  - player: "Jillian Tente"
+    points: 1
+  - player: "Kali Mass"
+    points: 1
+  - player: "Michael Q Novak"
+    points: 1
+  - player: "Michael Scarpelli"
+    points: 1
+  - player: "RJ Vida"
+    points: 1
+  - player: "Thomas Deen"
+    points: 1
+  - player: "Thomas M. Rocca"
+    points: 1
+  - player: "Travis Bundy"
+    points: 1

--- a/data/results/2024-clearwater-fl-national.yaml
+++ b/data/results/2024-clearwater-fl-national.yaml
@@ -1,0 +1,18 @@
+event: "Clearwater, FL National"
+category: national
+year: 2024
+results:
+  - player: "Michael Brady"
+    points: 3
+  - player: "Clayton Taylor"
+    points: 3
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1

--- a/data/results/2024-fall-league.yaml
+++ b/data/results/2024-fall-league.yaml
@@ -1,0 +1,36 @@
+event: "Fall League"
+category: league
+year: 2024
+results:
+  - player: "Mark Malatt"
+    points: 10
+  - player: "Tyler Berry"
+    points: 8
+  - player: "Jen Durham"
+    points: 7
+  - player: "James Kessler"
+    points: 6
+  - player: "Michael A Dritto"
+    points: 5
+  - player: "Laura Silverman"
+    points: 5
+  - player: "Katie Guarascio"
+    points: 3
+  - player: "Fabiola Camacho"
+    points: 2
+  - player: "Diana Diaz"
+    points: 2
+  - player: "Joe Brennan"
+    points: 2
+  - player: "Maggie Jones"
+    points: 2
+  - player: "Jason Kontny"
+    points: 2
+  - player: "Dana Rotz"
+    points: 1
+  - player: "Eileen Rohan"
+    points: 1
+  - player: "Kai Brown"
+    points: 1
+  - player: "Ryan O'Maley"
+    points: 1

--- a/data/results/2024-grow-the-game.yaml
+++ b/data/results/2024-grow-the-game.yaml
@@ -1,0 +1,34 @@
+event: "Grow the Game"
+category: ilsa
+year: 2024
+results:
+  - player: "Dave Berman"
+    points: 7
+  - player: "Teddy Wachholz"
+    points: 7
+  - player: "Tyler Janese"
+    points: 5
+  - player: "Derek Slater"
+    points: 5
+  - player: "Michael A Dritto"
+    points: 3
+  - player: "Kevin Reedy"
+    points: 3
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Fabiola Camacho"
+    points: 2
+  - player: "Doug Moring"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Spencer McNeil"
+    points: 1
+  - player: "Jason Klis"
+    points: 1
+  - player: "Josh Petras"
+    points: 1
+  - player: "Willy Palivos"
+    points: 1

--- a/data/results/2024-hendersonville-nc-national.yaml
+++ b/data/results/2024-hendersonville-nc-national.yaml
@@ -1,0 +1,22 @@
+event: "Hendersonville, NC National"
+category: national
+year: 2024
+results:
+  - player: "Paul Assad"
+    points: 18
+  - player: "George Eric Brown"
+    points: 9
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Michael Brady"
+    points: 6
+  - player: "Amelia Burger"
+    points: 5
+  - player: "Doug Moring"
+    points: 4
+  - player: "Abby Manville"
+    points: 2
+  - player: "Christine Page"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1

--- a/data/results/2024-lakeside-oh-national-tournaments.yaml
+++ b/data/results/2024-lakeside-oh-national-tournaments.yaml
@@ -1,0 +1,36 @@
+event: "Lakeside, OH National Tournaments"
+category: national
+year: 2024
+results:
+  - player: "Paul Assad"
+    points: 20
+  - player: "Abby Manville"
+    points: 14
+  - player: "Lauren Seesel"
+    points: 12
+  - player: "Sean Reddington"
+    points: 8
+  - player: "Jason Hiquet"
+    points: 8
+  - player: "Fabiola Camacho"
+    points: 8
+  - player: "Robert O'mahoney"
+    points: 5
+  - player: "Aaron Politsky"
+    points: 5
+  - player: "Christine Page"
+    points: 4
+  - player: "Al Manville"
+    points: 3
+  - player: "Doug Moring"
+    points: 2
+  - player: "Amelia Burger"
+    points: 2
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Trevor Hess"
+    points: 1

--- a/data/results/2024-mad-hatter.yaml
+++ b/data/results/2024-mad-hatter.yaml
@@ -1,0 +1,20 @@
+event: "Mad Hatter"
+category: ilsa
+year: 2024
+results:
+  - player: "Dave Berman"
+    points: 10
+  - player: "James Parizek"
+    points: 8
+  - player: "James Gallagher"
+    points: 5
+  - player: "David Smith"
+    points: 5
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Tyler Janese"
+    points: 2
+  - player: "Spencer McNeil"
+    points: 2
+  - player: "Hailey Staunton"
+    points: 2

--- a/data/results/2024-mirror-lake-championship.yaml
+++ b/data/results/2024-mirror-lake-championship.yaml
@@ -1,0 +1,148 @@
+event: "Mirror Lake Championship"
+category: championship
+year: 2024
+results:
+  - player: "Paul Assad"
+    points: 9
+  - player: "Michael Brady"
+    points: 6
+  - player: "Jordon Novak"
+    points: 4
+  - player: "Derek Falk"
+    points: 3
+  - player: "Dave Berman"
+    points: 1
+  - player: "Sean Reddington"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Mark Malatt"
+    points: 1
+  - player: "Kevin Wickman"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Michael A Dritto"
+    points: 1
+  - player: "Aaron Politsky"
+    points: 1
+  - player: "James Parizek"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Adam Jamrozy"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Dustin Kozal"
+    points: 1
+  - player: "Neal Hamer"
+    points: 1
+  - player: "Teddy Wachholz"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Christine Page"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Kristen Haut"
+    points: 1
+  - player: "Brian O'Connell"
+    points: 1
+  - player: "Clayton Taylor"
+    points: 1
+  - player: "Joe Brennan"
+    points: 1
+  - player: "Kiernan Ambrose"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Kate Fitzgerald"
+    points: 1
+  - player: "Kevin Reedy"
+    points: 1
+  - player: "Kristina Walter"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Craig Kelbus"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Emma Kehm"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Michelle DiMaggio"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Carlie DeMelo"
+    points: 1
+  - player: "Emily Ellsworth"
+    points: 1
+  - player: "Grace Fourman"
+    points: 1
+  - player: "Jonathan Schnapp"
+    points: 1
+  - player: "Roy Wicklund"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "Andy Norton"
+    points: 1
+  - player: "Brandon Queen"
+    points: 1
+  - player: "Cortney Norton"
+    points: 1
+  - player: "Dana Rotz"
+    points: 1
+  - player: "Jillian Madden"
+    points: 1
+  - player: "Mike Schmitt"
+    points: 1
+  - player: "Natalie Gabrenya"
+    points: 1
+  - player: "Sarah Osako"
+    points: 1
+  - player: "Scott Montgomery"
+    points: 1
+  - player: "Stephanie Swain"
+    points: 1
+  - player: "Thomas Gustafson"
+    points: 1
+  - player: "Timothy Hosty"
+    points: 1
+  - player: "Voltaire Alanguilan"
+    points: 1
+  - player: "Alan Rosetti"
+    points: 1
+  - player: "Dean A Refakes"
+    points: 1
+  - player: "Jaime Etsch"
+    points: 1
+  - player: "James Devine"
+    points: 1
+  - player: "Jessica Badger"
+    points: 1
+  - player: "John Shaw"
+    points: 1
+  - player: "Larry Hart"
+    points: 1
+  - player: "Luke Wesolowski"
+    points: 1
+  - player: "Marjorie O'Connor"
+    points: 1
+  - player: "Thomas Elwood"
+    points: 1

--- a/data/results/2024-mirror-lake-championship.yaml
+++ b/data/results/2024-mirror-lake-championship.yaml
@@ -1,5 +1,5 @@
 event: "Mirror Lake Championship"
-category: championship
+category: other
 year: 2024
 results:
   - player: "Paul Assad"

--- a/data/results/2024-spring-league.yaml
+++ b/data/results/2024-spring-league.yaml
@@ -1,0 +1,42 @@
+event: "Spring League"
+category: league
+year: 2024
+results:
+  - player: "Jason Hiquet"
+    points: 10
+  - player: "Noelle Riese"
+    points: 10
+  - player: "John Windler"
+    points: 8
+  - player: "Sam Boebel"
+    points: 8
+  - player: "Matthew Miller"
+    points: 6
+  - player: "Emma Brown-Wasielewski"
+    points: 6
+  - player: "Rachel Reichman"
+    points: 5
+  - player: "John Allen"
+    points: 5
+  - player: "Radhika Tandon"
+    points: 3
+  - player: "Tyler Berry"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Erik Windler"
+    points: 2
+  - player: "Juliana Kaye"
+    points: 2
+  - player: "Spencer McNeil"
+    points: 2
+  - player: "Michelle DiMaggio"
+    points: 2
+  - player: "Jason Klis"
+    points: 2
+  - player: "Charlie Ferreira"
+    points: 2
+  - player: "Jordan Halpern"
+    points: 2
+  - player: "Karla Baumler"
+    points: 1

--- a/data/results/2024-st-pete-fl-national-tournament.yaml
+++ b/data/results/2024-st-pete-fl-national-tournament.yaml
@@ -1,0 +1,66 @@
+event: "St Pete, FL National Tournament"
+category: national
+year: 2024
+results:
+  - player: "Doug Moring"
+    points: 8
+  - player: "Aaron Politsky"
+    points: 8
+  - player: "James Gallagher"
+    points: 3
+  - player: "Samantha Gallagher"
+    points: 3
+  - player: "Robert O'mahoney"
+    points: 1
+  - player: "Tyler Berry"
+    points: 1
+  - player: "Michael Brady"
+    points: 1
+  - player: "Sean Reddington"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Fabiola Camacho"
+    points: 1
+  - player: "George Eric Brown"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Jeff Ziev"
+    points: 1
+  - player: "Juliana Kaye"
+    points: 1
+  - player: "Amelia Burger"
+    points: 1
+  - player: "Christine Page"
+    points: 1
+  - player: "Al Manville"
+    points: 1
+  - player: "Matthew Miller"
+    points: 1
+  - player: "Clayton Taylor"
+    points: 1
+  - player: "Missy Kayko"
+    points: 1
+  - player: "Anna Balchunas"
+    points: 1
+  - player: "Daniel Love Jr"
+    points: 1
+  - player: "Justin Latta"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Thanh Seybold"
+    points: 1
+  - player: "Christy Gregory"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Nicholas Goldman"
+    points: 1
+  - player: "Brandon Queen"
+    points: 1
+  - player: "Stephanie Swain"
+    points: 1
+  - player: "Josh Dulabaum"
+    points: 1

--- a/data/results/2024-tangsgiving.yaml
+++ b/data/results/2024-tangsgiving.yaml
@@ -1,5 +1,5 @@
 event: "Tangsgiving"
-category: ilsa
+category: other
 year: 2024
 results:
   - player: "Adam Jamrozy"

--- a/data/results/2024-tangsgiving.yaml
+++ b/data/results/2024-tangsgiving.yaml
@@ -1,0 +1,20 @@
+event: "Tangsgiving"
+category: ilsa
+year: 2024
+results:
+  - player: "Adam Jamrozy"
+    points: 10
+  - player: "Jeff Ziev"
+    points: 8
+  - player: "Tyler Berry"
+    points: 6
+  - player: "Eric R Koch"
+    points: 5
+  - player: "Erik Windler"
+    points: 4
+  - player: "Tim Nicholson"
+    points: 3
+  - player: "Matt Nakano"
+    points: 2
+  - player: "Brian DeMaio"
+    points: 1

--- a/data/results/2024-valentang-s-day.yaml
+++ b/data/results/2024-valentang-s-day.yaml
@@ -1,0 +1,20 @@
+event: "Valentang's Day"
+category: ilsa
+year: 2024
+results:
+  - player: "John Windler"
+    points: 10
+  - player: "Joshua D Garrett"
+    points: 8
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Michael A Dritto"
+    points: 5
+  - player: "Sean Reddington"
+    points: 4
+  - player: "Juliana Kaye"
+    points: 3
+  - player: "Matt Nakano"
+    points: 2
+  - player: "Andrew Collier"
+    points: 1

--- a/data/results/2024-valentang-s-day.yaml
+++ b/data/results/2024-valentang-s-day.yaml
@@ -1,5 +1,5 @@
 event: "Valentang's Day"
-category: ilsa
+category: other
 year: 2024
 results:
   - player: "John Windler"

--- a/data/results/2024-winter-league.yaml
+++ b/data/results/2024-winter-league.yaml
@@ -1,0 +1,26 @@
+event: "Winter League"
+category: league
+year: 2024
+results:
+  - player: "Mathew Savill"
+    points: 10
+  - player: "Kevin Wickman"
+    points: 8
+  - player: "Maxwell Julius"
+    points: 6
+  - player: "Jordon Novak"
+    points: 5
+  - player: "William Kirchhoff"
+    points: 3
+  - player: "Tyler Berry"
+    points: 2
+  - player: "Mark Malatt"
+    points: 2
+  - player: "Gabe Paul"
+    points: 2
+  - player: "August Etsch"
+    points: 2
+  - player: "Joseph Brett Spangler"
+    points: 2
+  - player: "Mike Schmitt"
+    points: 1

--- a/data/results/2024-winter-olympics.yaml
+++ b/data/results/2024-winter-olympics.yaml
@@ -1,0 +1,36 @@
+event: "Winter Olympics"
+category: ilsa
+year: 2024
+results:
+  - player: "Andrew Collier"
+    points: 10
+  - player: "Dustin Kozal"
+    points: 10
+  - player: "Kevin Wickman"
+    points: 8
+  - player: "Neal Hamer"
+    points: 8
+  - player: "Tyler Berry"
+    points: 5
+  - player: "Mark Malatt"
+    points: 5
+  - player: "James Parizek"
+    points: 5
+  - player: "Kristen Haut"
+    points: 5
+  - player: "Robert O'mahoney"
+    points: 2
+  - player: "Kim Marek"
+    points: 2
+  - player: "Joshua D Garrett"
+    points: 2
+  - player: "Jordon Novak"
+    points: 2
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Diana Diaz"
+    points: 2
+  - player: "Kate Fitzgerald"
+    points: 2
+  - player: "Kristina Walter"
+    points: 2

--- a/data/results/2025-brooklyn-ny-national.yaml
+++ b/data/results/2025-brooklyn-ny-national.yaml
@@ -1,0 +1,74 @@
+event: "Brooklyn, NY National"
+category: national
+year: 2025
+results:
+  - player: "Paul Assad"
+    points: 10
+  - player: "Mark Malatt"
+    points: 7
+  - player: "Michael A Dritto"
+    points: 7
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Kim Marek"
+    points: 6
+  - player: "Sammy Wachholz"
+    points: 5
+  - player: "Teddy Wachholz"
+    points: 5
+  - player: "Karson Bodnovich"
+    points: 5
+  - player: "Joe Brennan"
+    points: 5
+  - player: "Maggie Jones"
+    points: 4
+  - player: "Jaime Etsch"
+    points: 4
+  - player: "Trevor Hess"
+    points: 4
+  - player: "John Windler"
+    points: 3
+  - player: "Erik Windler"
+    points: 3
+  - player: "Joseph Brett Spangler"
+    points: 3
+  - player: "Gabe Paul"
+    points: 3
+  - player: "Jordon Novak"
+    points: 3
+  - player: "Abby Manville"
+    points: 3
+  - player: "Mathew Savill"
+    points: 3
+  - player: "Rachel Reichman"
+    points: 3
+  - player: "James Kessler"
+    points: 3
+  - player: "Dan Love"
+    points: 3
+  - player: "Steven Perry"
+    points: 2
+  - player: "Tyler Berry"
+    points: 2
+  - player: "Natalie Gabrenya"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Matthew Miller"
+    points: 2
+  - player: "Nick Haynes"
+    points: 2
+  - player: "Jillian Madden"
+    points: 2
+  - player: "Kayla Gerst"
+    points: 2
+  - player: "Kristina Walter"
+    points: 2
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "Kiernan Ambrose"
+    points: 1
+  - player: "Jessica Badger"
+    points: 1

--- a/data/results/2025-challenge-fall-league.yaml
+++ b/data/results/2025-challenge-fall-league.yaml
@@ -1,0 +1,156 @@
+event: "Challenge Fall League"
+category: league
+year: 2025
+results:
+  - player: "Joseph Brett Spangler"
+    points: 25
+  - player: "John Allen"
+    points: 18
+  - player: "Matthew Miller"
+    points: 16
+  - player: "Tyler Berry"
+    points: 14
+  - player: "Erik Windler"
+    points: 11
+  - player: "Dave Berman"
+    points: 11
+  - player: "Cody Uidl"
+    points: 11
+  - player: "Mathew Savill"
+    points: 11
+  - player: "Paul Assad"
+    points: 9
+  - player: "John Windler"
+    points: 9
+  - player: "Mark Malatt"
+    points: 9
+  - player: "Kate Fitzgerald"
+    points: 9
+  - player: "Maxwell Julius"
+    points: 9
+  - player: "Adam Rahmel"
+    points: 9
+  - player: "Justin Latta"
+    points: 9
+  - player: "Eric R Koch"
+    points: 9
+  - player: "Steven Perry"
+    points: 7
+  - player: "Robert O'mahoney"
+    points: 7
+  - player: "Fabiola Camacho"
+    points: 7
+  - player: "James Gallagher"
+    points: 7
+  - player: "Michael A Dritto"
+    points: 7
+  - player: "Natalie Gabrenya"
+    points: 7
+  - player: "Derek Falk"
+    points: 7
+  - player: "Dana Rotz"
+    points: 7
+  - player: "Adam Jamrozy"
+    points: 7
+  - player: "Matt Nakano"
+    points: 7
+  - player: "Jaime Etsch"
+    points: 7
+  - player: "James Kessler"
+    points: 7
+  - player: "Tyler Janese"
+    points: 7
+  - player: "Spencer McNeil"
+    points: 7
+  - player: "Brian DeMaio"
+    points: 7
+  - player: "Luke Wesolowski"
+    points: 7
+  - player: "Amanda DavyRomano"
+    points: 5
+  - player: "Gabe Paul"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Jordon Novak"
+    points: 2
+  - player: "Lauren Seesel"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2
+  - player: "Abby Manville"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Jason Hiquet"
+    points: 2
+  - player: "Karson Bodnovich"
+    points: 2
+  - player: "Andrew Collier"
+    points: 2
+  - player: "Nick Haynes"
+    points: 2
+  - player: "Joe Brennan"
+    points: 2
+  - player: "David Smith"
+    points: 2
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Maggie Jones"
+    points: 2
+  - player: "August Etsch"
+    points: 2
+  - player: "Joshua D Garrett"
+    points: 2
+  - player: "Andrew Abern"
+    points: 2
+  - player: "Diana Diaz"
+    points: 2
+  - player: "Kiernan Ambrose"
+    points: 2
+  - player: "Radhika Tandon"
+    points: 2
+  - player: "Emily Power"
+    points: 2
+  - player: "Laura Silverman"
+    points: 2
+  - player: "Willy Palivos"
+    points: 2
+  - player: "Andrew Seputis"
+    points: 2
+  - player: "Jillian Madden"
+    points: 2
+  - player: "Adam Vavrick"
+    points: 2
+  - player: "Kayla Gerst"
+    points: 2
+  - player: "Jen Durham"
+    points: 2
+  - player: "Thomas Elwood"
+    points: 2
+  - player: "Brian O'Connell"
+    points: 2
+  - player: "Ian McKee"
+    points: 2
+  - player: "Javoun Baker"
+    points: 2
+  - player: "Kathleen Stark"
+    points: 2
+  - player: "Mike Vehlewald"
+    points: 2
+  - player: "Brett Pontoni"
+    points: 2
+  - player: "Hailey Staunton"
+    points: 2
+  - player: "Brian Levy"
+    points: 2
+  - player: "Genell Walcott"
+    points: 2
+  - player: "Patrick Ragan"
+    points: 2
+  - player: "Spencer Hill"
+    points: 2

--- a/data/results/2025-challenge-summer-doubles.yaml
+++ b/data/results/2025-challenge-summer-doubles.yaml
@@ -1,0 +1,132 @@
+event: "Challenge Summer Doubles"
+category: ilsa
+year: 2025
+results:
+  - player: "John Allen"
+    points: 14
+  - player: "Michael A Dritto"
+    points: 14
+  - player: "Steven Perry"
+    points: 9
+  - player: "Tyler Berry"
+    points: 9
+  - player: "Joseph Brett Spangler"
+    points: 8
+  - player: "Gabe Paul"
+    points: 8
+  - player: "Adam Jamrozy"
+    points: 6
+  - player: "Andrew Collier"
+    points: 6
+  - player: "Maxwell Julius"
+    points: 5
+  - player: "Adam Rahmel"
+    points: 5
+  - player: "Natalie Gabrenya"
+    points: 5
+  - player: "Mathew Savill"
+    points: 5
+  - player: "James Kessler"
+    points: 5
+  - player: "Thomas P Mulroe"
+    points: 5
+  - player: "Willy Palivos"
+    points: 5
+  - player: "Jillian Madden"
+    points: 5
+  - player: "John Windler"
+    points: 3
+  - player: "Erik Windler"
+    points: 3
+  - player: "Fabiola Camacho"
+    points: 3
+  - player: "Lauren Seesel"
+    points: 3
+  - player: "Justin Latta"
+    points: 3
+  - player: "Sean Reddington"
+    points: 3
+  - player: "David Smith"
+    points: 3
+  - player: "Maggie Jones"
+    points: 3
+  - player: "Amanda DavyRomano"
+    points: 3
+  - player: "August Etsch"
+    points: 3
+  - player: "James Parizek"
+    points: 3
+  - player: "Kristen Haut"
+    points: 3
+  - player: "Craig Kelbus"
+    points: 3
+  - player: "Josh Petras"
+    points: 3
+  - player: "Ike Baya"
+    points: 3
+  - player: "Thomas Elwood"
+    points: 3
+  - player: "Paul Assad"
+    points: 2
+  - player: "Mark Malatt"
+    points: 2
+  - player: "Dave Berman"
+    points: 2
+  - player: "Kate Fitzgerald"
+    points: 2
+  - player: "James Gallagher"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2
+  - player: "Derek Falk"
+    points: 2
+  - player: "Abby Manville"
+    points: 2
+  - player: "Teddy Wachholz"
+    points: 2
+  - player: "Jason Hiquet"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Eric R Koch"
+    points: 2
+  - player: "Jaime Etsch"
+    points: 2
+  - player: "Kiernan Ambrose"
+    points: 2
+  - player: "Samantha Gallagher"
+    points: 2
+  - player: "Doug Moring"
+    points: 2
+  - player: "Andrew Seputis"
+    points: 2
+  - player: "Adam Vavrick"
+    points: 2
+  - player: "Brandon V"
+    points: 2
+  - player: "Shannon Schupbach"
+    points: 2
+  - player: "Jen Durham"
+    points: 2
+  - player: "Brian O'Connell"
+    points: 2
+  - player: "KO"
+    points: 2
+  - player: "Michelle DiMaggio"
+    points: 2
+  - player: "Rashid Durham"
+    points: 2
+  - player: "Thomas Gustafson"
+    points: 2
+  - player: "Scott Montgomery"
+    points: 2
+  - player: "Chris Abernathy"
+    points: 2
+  - player: "Dan Dubbeld"
+    points: 2
+  - player: "Rebecca Franklin"
+    points: 2

--- a/data/results/2025-challenge-winter-league.yaml
+++ b/data/results/2025-challenge-winter-league.yaml
@@ -1,0 +1,136 @@
+event: "Challenge Winter League"
+category: league
+year: 2025
+results:
+  - player: "Steven Perry"
+    points: 25
+  - player: "Adam Rahmel"
+    points: 18
+  - player: "Maxwell Julius"
+    points: 16
+  - player: "Rebecca Mendoza"
+    points: 14
+  - player: "John Windler"
+    points: 11
+  - player: "John Allen"
+    points: 11
+  - player: "Jordon Novak"
+    points: 11
+  - player: "Andrew Abern"
+    points: 11
+  - player: "Joseph Brett Spangler"
+    points: 9
+  - player: "Mark Malatt"
+    points: 9
+  - player: "Dave Berman"
+    points: 9
+  - player: "Gabe Paul"
+    points: 9
+  - player: "James Gallagher"
+    points: 9
+  - player: "Sean Reddington"
+    points: 9
+  - player: "Mathew Savill"
+    points: 9
+  - player: "Nick Haynes"
+    points: 9
+  - player: "Tyler Berry"
+    points: 7
+  - player: "Cody Uidl"
+    points: 7
+  - player: "Derek Falk"
+    points: 7
+  - player: "Adam Jamrozy"
+    points: 7
+  - player: "Joe Brennan"
+    points: 7
+  - player: "David Smith"
+    points: 7
+  - player: "Kevin Reedy"
+    points: 7
+  - player: "August Etsch"
+    points: 7
+  - player: "Matt Nakano"
+    points: 7
+  - player: "Joshua D Garrett"
+    points: 7
+  - player: "James Parizek"
+    points: 7
+  - player: "Kristen Haut"
+    points: 7
+  - player: "Craig Kelbus"
+    points: 7
+  - player: "Josh Petras"
+    points: 7
+  - player: "Jack Smith-Moore"
+    points: 7
+  - player: "Thomas Deen"
+    points: 7
+  - player: "Andrew Collier"
+    points: 5
+  - player: "Erik Windler"
+    points: 2
+  - player: "Robert O'mahoney"
+    points: 2
+  - player: "Fabiola Camacho"
+    points: 2
+  - player: "Michael A Dritto"
+    points: 2
+  - player: "Natalie Gabrenya"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Lauren Seesel"
+    points: 2
+  - player: "Jason Hiquet"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Maggie Jones"
+    points: 2
+  - player: "Amanda DavyRomano"
+    points: 2
+  - player: "Eric R Koch"
+    points: 2
+  - player: "Jaime Etsch"
+    points: 2
+  - player: "Diana Diaz"
+    points: 2
+  - player: "Kiernan Ambrose"
+    points: 2
+  - player: "Tyler Janese"
+    points: 2
+  - player: "Spencer McNeil"
+    points: 2
+  - player: "Willy Palivos"
+    points: 2
+  - player: "Brian DeMaio"
+    points: 2
+  - player: "Andrew Seputis"
+    points: 2
+  - player: "Adam Vavrick"
+    points: 2
+  - player: "Ike Baya"
+    points: 2
+  - player: "Luke Wesolowski"
+    points: 2
+  - player: "Joseph Tijerina"
+    points: 2
+  - player: "Kevin Hein"
+    points: 2
+  - player: "KO"
+    points: 2
+  - player: "Ian McKee"
+    points: 2
+  - player: "John Seeder"
+    points: 2
+  - player: "Sam Boebel"
+    points: 2
+  - player: "Kathleen Stark"
+    points: 2
+  - player: "Ashley Addington"
+    points: 2
+  - player: "Charlie Ferreira"
+    points: 2
+  - player: "Derek Slater"
+    points: 2

--- a/data/results/2025-chicago-il-national.yaml
+++ b/data/results/2025-chicago-il-national.yaml
@@ -1,0 +1,180 @@
+event: "Chicago, IL National"
+category: national
+year: 2025
+results:
+  - player: "John Windler"
+    points: 17
+  - player: "Erik Windler"
+    points: 17
+  - player: "Steven Perry"
+    points: 12
+  - player: "Tyler Berry"
+    points: 12
+  - player: "Maxwell Julius"
+    points: 11
+  - player: "Adam Rahmel"
+    points: 11
+  - player: "Robert O'mahoney"
+    points: 9
+  - player: "Karson Bodnovich"
+    points: 9
+  - player: "Joe Brennan"
+    points: 9
+  - player: "Kim Marek"
+    points: 9
+  - player: "Cody Uidl"
+    points: 8
+  - player: "Brad Uidl"
+    points: 8
+  - player: "Paul Assad"
+    points: 6
+  - player: "Mark Malatt"
+    points: 6
+  - player: "Dave Berman"
+    points: 6
+  - player: "Derek Falk"
+    points: 6
+  - player: "Justin Latta"
+    points: 6
+  - player: "Matthew Miller"
+    points: 6
+  - player: "Andrew Collier"
+    points: 6
+  - player: "August Etsch"
+    points: 6
+  - player: "Diana Diaz"
+    points: 6
+  - player: "Emily Ellsworth"
+    points: 6
+  - player: "Juliana Kaye"
+    points: 6
+  - player: "Jessica Badger"
+    points: 6
+  - player: "Michael Q Novak"
+    points: 6
+  - player: "Neal Hamer"
+    points: 6
+  - player: "Joseph Brett Spangler"
+    points: 5
+  - player: "Gabe Paul"
+    points: 5
+  - player: "Michael A Dritto"
+    points: 5
+  - player: "Sammy Wachholz"
+    points: 5
+  - player: "Abby Manville"
+    points: 5
+  - player: "Teddy Wachholz"
+    points: 5
+  - player: "Nick Haynes"
+    points: 5
+  - player: "Rachel Reichman"
+    points: 5
+  - player: "Vishal Shah"
+    points: 5
+  - player: "Eric R Koch"
+    points: 5
+  - player: "James Parizek"
+    points: 5
+  - player: "Emily Power"
+    points: 5
+  - player: "Kristen Haut"
+    points: 5
+  - player: "Spencer McNeil"
+    points: 5
+  - player: "Thomas P Mulroe"
+    points: 5
+  - player: "Willy Palivos"
+    points: 5
+  - player: "Andrew Seputis"
+    points: 5
+  - player: "Aaron Politsky"
+    points: 5
+  - player: "Adam Vavrick"
+    points: 5
+  - player: "Jack Smith-Moore"
+    points: 5
+  - player: "Jen Durham"
+    points: 5
+  - player: "John Bistolfo"
+    points: 5
+  - player: "Kevin Hein"
+    points: 5
+  - player: "Kristina Walter"
+    points: 5
+  - player: "Rashid Durham"
+    points: 5
+  - player: "Thomas Gustafson"
+    points: 5
+  - player: "Steve Sobel"
+    points: 5
+  - player: "Mike Schmitt"
+    points: 5
+  - player: "Shane Robinson"
+    points: 5
+  - player: "James Gallagher"
+    points: 3
+  - player: "Dana Rotz"
+    points: 3
+  - player: "Kevin Reedy"
+    points: 3
+  - player: "Samantha Gallagher"
+    points: 3
+  - player: "Daniel Love Jr"
+    points: 3
+  - player: "Kayla Gerst"
+    points: 3
+  - player: "Connor Morehouse"
+    points: 3
+  - player: "KO"
+    points: 3
+  - player: "Michelle DiMaggio"
+    points: 3
+  - player: "Anna Balchunas"
+    points: 3
+  - player: "John Allen"
+    points: 2
+  - player: "Kate Fitzgerald"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2
+  - player: "Jen Walton"
+    points: 2
+  - player: "Maggie Jones"
+    points: 2
+  - player: "Amanda DavyRomano"
+    points: 2
+  - player: "Joshua D Garrett"
+    points: 2
+  - player: "James Kessler"
+    points: 2
+  - player: "Kiernan Ambrose"
+    points: 2
+  - player: "Doug Moring"
+    points: 2
+  - player: "Craig Kelbus"
+    points: 2
+  - player: "Brandon V"
+    points: 2
+  - player: "Don Drake"
+    points: 2
+  - player: "Ike Baya"
+    points: 2
+  - player: "Brian O'Connell"
+    points: 2
+  - player: "Ian McKee"
+    points: 2
+  - player: "Susan R"
+    points: 2
+  - player: "Brett Pontoni"
+    points: 2
+  - player: "Ashly Powley"
+    points: 2
+  - player: "Emma Kehm"
+    points: 2
+  - player: "Jesse Gainsburg"
+    points: 2
+  - player: "Jordan Halpern"
+    points: 2
+  - player: "Lizzy Tiritilli"
+    points: 2

--- a/data/results/2025-clearwater-fl-national.yaml
+++ b/data/results/2025-clearwater-fl-national.yaml
@@ -1,0 +1,62 @@
+event: "Clearwater, FL National"
+category: national
+year: 2025
+results:
+  - player: "Paul Assad"
+    points: 10
+  - player: "Erik Hahmann"
+    points: 10
+  - player: "Daniel Love Jr"
+    points: 5
+  - player: "Steven Perry"
+    points: 4
+  - player: "Tyler Berry"
+    points: 4
+  - player: "Kevin Reedy"
+    points: 4
+  - player: "Doug Moring"
+    points: 4
+  - player: "John Windler"
+    points: 3
+  - player: "Erik Windler"
+    points: 3
+  - player: "Mark Malatt"
+    points: 3
+  - player: "Robert O'mahoney"
+    points: 3
+  - player: "Kate Fitzgerald"
+    points: 3
+  - player: "James Gallagher"
+    points: 3
+  - player: "Natalie Gabrenya"
+    points: 3
+  - player: "Sammy Wachholz"
+    points: 3
+  - player: "Dana Rotz"
+    points: 3
+  - player: "Teddy Wachholz"
+    points: 3
+  - player: "Kim Marek"
+    points: 3
+  - player: "Samantha Gallagher"
+    points: 3
+  - player: "Aaron Politsky"
+    points: 3
+  - player: "Lauren Seesel"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "John Allen"
+    points: 1
+  - player: "Fabiola Camacho"
+    points: 1
+  - player: "Rebecca Mendoza"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Sean Reddington"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "August Etsch"
+    points: 1

--- a/data/results/2025-fundamentals-fall-league.yaml
+++ b/data/results/2025-fundamentals-fall-league.yaml
@@ -1,0 +1,66 @@
+event: "FUNdamentals Fall League"
+category: league
+year: 2025
+results:
+  - player: "Melody Contreras"
+    points: 19
+  - player: "Jen Walton"
+    points: 13
+  - player: "Marjorie O'Connor"
+    points: 11
+  - player: "Spencer Mooney"
+    points: 9
+  - player: "Eric Abel"
+    points: 8
+  - player: "Ashley De La Rosa"
+    points: 8
+  - player: "John Reavey"
+    points: 8
+  - player: "Terence Young"
+    points: 8
+  - player: "Vishal Shah"
+    points: 6
+  - player: "Shannon Schupbach"
+    points: 6
+  - player: "Anthony Staffa"
+    points: 6
+  - player: "Jonathan Eng"
+    points: 6
+  - player: "Magdalena Donnels"
+    points: 6
+  - player: "Ray Gallagher"
+    points: 6
+  - player: "Don Drake"
+    points: 2
+  - player: "Zachariah Wilson"
+    points: 2
+  - player: "Jackie Semko"
+    points: 2
+  - player: "Jessica Martens"
+    points: 2
+  - player: "Thorsten Sahlin"
+    points: 2
+  - player: "Karla Baumler"
+    points: 2
+  - player: "Matt Monnette"
+    points: 2
+  - player: "Patrick Corcoran"
+    points: 2
+  - player: "Ilene Davis"
+    points: 2
+  - player: "Jason Kontny"
+    points: 2
+  - player: "Joshua Simpson"
+    points: 2
+  - player: "Albert Dizenzo"
+    points: 2
+  - player: "Jeremy Bloomfield"
+    points: 2
+  - player: "Max Timm"
+    points: 2
+  - player: "Rebecca McHenry"
+    points: 2
+  - player: "Rene Lamb"
+    points: 2
+  - player: "Ryan O'Maley"
+    points: 2

--- a/data/results/2025-fundamentals-summer-doubles.yaml
+++ b/data/results/2025-fundamentals-summer-doubles.yaml
@@ -1,0 +1,68 @@
+event: "FUNdamentals Summer Doubles"
+category: ilsa
+year: 2025
+results:
+  - player: "Jordon Novak"
+    points: 10
+  - player: "Rachel Reichman"
+    points: 10
+  - player: "Jen Walton"
+    points: 6
+  - player: "Don Drake"
+    points: 6
+  - player: "Nick Haynes"
+    points: 5
+  - player: "Kayla Gerst"
+    points: 5
+  - player: "Dana Rotz"
+    points: 4
+  - player: "Radhika Tandon"
+    points: 4
+  - player: "Cody Uidl"
+    points: 3
+  - player: "Vishal Shah"
+    points: 3
+  - player: "Brad Uidl"
+    points: 3
+  - player: "Eric Abel"
+    points: 3
+  - player: "Anthony Staffa"
+    points: 3
+  - player: "CJ Colston"
+    points: 3
+  - player: "Akiko Moorman"
+    points: 3
+  - player: "Philip Foss"
+    points: 3
+  - player: "Laura Silverman"
+    points: 1
+  - player: "Jillian Tente"
+    points: 1
+  - player: "Jonathan Eng"
+    points: 1
+  - player: "Jessica Martens"
+    points: 1
+  - player: "Kathleen Stark"
+    points: 1
+  - player: "Michael Scarpelli"
+    points: 1
+  - player: "Chris Doyle"
+    points: 1
+  - player: "Ilene Davis"
+    points: 1
+  - player: "Jason Kontny"
+    points: 1
+  - player: "Joshua Simpson"
+    points: 1
+  - player: "Wesley Bagby"
+    points: 1
+  - player: "Amanda McCafferty"
+    points: 1
+  - player: "John Hayden"
+    points: 1
+  - player: "Matthew Bender"
+    points: 1
+  - player: "Tyler McMullen"
+    points: 1
+  - player: "Victoria Reynoso"
+    points: 1

--- a/data/results/2025-fundamentals-winter-league.yaml
+++ b/data/results/2025-fundamentals-winter-league.yaml
@@ -1,0 +1,38 @@
+event: "FUNdamentals Winter League"
+category: league
+year: 2025
+results:
+  - player: "Kate Fitzgerald"
+    points: 17
+  - player: "Spicy Boy"
+    points: 11
+  - player: "Vishal Shah"
+    points: 9
+  - player: "Laura Silverman"
+    points: 8
+  - player: "Teddy Wachholz"
+    points: 6
+  - player: "Emily Power"
+    points: 6
+  - player: "Juliana Kaye"
+    points: 6
+  - player: "CJ Colston"
+    points: 6
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Radhika Tandon"
+    points: 2
+  - player: "Jonathan Eng"
+    points: 2
+  - player: "Hailey Staunton"
+    points: 2
+  - player: "Karla Baumler"
+    points: 2
+  - player: "Matt Monnette"
+    points: 2
+  - player: "Chris Doyle"
+    points: 2
+  - player: "Wesley Bagby"
+    points: 2
+  - player: "Vinnie Butera"
+    points: 2

--- a/data/results/2025-ilsa-field-trip.yaml
+++ b/data/results/2025-ilsa-field-trip.yaml
@@ -1,0 +1,58 @@
+event: "ILSA Field Trip"
+category: ilsa
+year: 2025
+results:
+  - player: "Paul Assad"
+    points: 10
+  - player: "Mark Malatt"
+    points: 10
+  - player: "Joseph Brett Spangler"
+    points: 6
+  - player: "Lauren Seesel"
+    points: 6
+  - player: "Dana Rotz"
+    points: 6
+  - player: "Jim Seesel"
+    points: 6
+  - player: "Steven Perry"
+    points: 5
+  - player: "Tyler Berry"
+    points: 5
+  - player: "Cody Uidl"
+    points: 5
+  - player: "Brad Uidl"
+    points: 5
+  - player: "James Gallagher"
+    points: 4
+  - player: "Natalie Gabrenya"
+    points: 4
+  - player: "Samantha Gallagher"
+    points: 4
+  - player: "Tyler Janese"
+    points: 4
+  - player: "David Smith"
+    points: 3
+  - player: "James Parizek"
+    points: 3
+  - player: "John Windler"
+    points: 1
+  - player: "John Allen"
+    points: 1
+  - player: "Dave Berman"
+    points: 1
+  - player: "Rebecca Mendoza"
+    points: 1
+  - player: "Sean Reddington"
+    points: 1
+  - player: "Jason Hiquet"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1
+  - player: "Jaime Etsch"
+    points: 1
+  - player: "Kiernan Ambrose"
+    points: 1
+  - player: "Jillian Tente"
+    points: 1
+  - player: "Michael Scarpelli"
+    points: 1

--- a/data/results/2025-ilsa-gameday.yaml
+++ b/data/results/2025-ilsa-gameday.yaml
@@ -1,0 +1,118 @@
+event: "ILSA Gameday"
+category: ilsa
+year: 2025
+results:
+  - player: "Joseph Brett Spangler"
+    points: 5
+  - player: "Dave Berman"
+    points: 5
+  - player: "James Gallagher"
+    points: 5
+  - player: "Andrew Collier"
+    points: 5
+  - player: "John Windler"
+    points: 3
+  - player: "Erik Windler"
+    points: 3
+  - player: "Mark Malatt"
+    points: 3
+  - player: "Gabe Paul"
+    points: 3
+  - player: "Kate Fitzgerald"
+    points: 3
+  - player: "Maxwell Julius"
+    points: 3
+  - player: "Sammy Wachholz"
+    points: 3
+  - player: "Dana Rotz"
+    points: 3
+  - player: "Jillian Tente"
+    points: 3
+  - player: "Zachariah Wilson"
+    points: 3
+  - player: "Javoun Baker"
+    points: 3
+  - player: "Shannon McCarthy"
+    points: 3
+  - player: "Steven Perry"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2
+  - player: "Jason Hiquet"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Spencer McNeil"
+    points: 2
+  - player: "Sam Boebel"
+    points: 2
+  - player: "Timothy Hosty"
+    points: 2
+  - player: "Patrick Corcoran"
+    points: 2
+  - player: "Emma Brown-Wasielewski"
+    points: 2
+  - player: "Tyler Berry"
+    points: 1
+  - player: "Paul Assad"
+    points: 1
+  - player: "John Allen"
+    points: 1
+  - player: "Robert O'mahoney"
+    points: 1
+  - player: "Adam Rahmel"
+    points: 1
+  - player: "Natalie Gabrenya"
+    points: 1
+  - player: "Jordon Novak"
+    points: 1
+  - player: "Lauren Seesel"
+    points: 1
+  - player: "Abby Manville"
+    points: 1
+  - player: "Adam Jamrozy"
+    points: 1
+  - player: "Nick Haynes"
+    points: 1
+  - player: "David Smith"
+    points: 1
+  - player: "Rachel Reichman"
+    points: 1
+  - player: "Maggie Jones"
+    points: 1
+  - player: "August Etsch"
+    points: 1
+  - player: "Joshua D Garrett"
+    points: 1
+  - player: "Jaime Etsch"
+    points: 1
+  - player: "James Kessler"
+    points: 1
+  - player: "Diana Diaz"
+    points: 1
+  - player: "James Parizek"
+    points: 1
+  - player: "Radhika Tandon"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Kristen Haut"
+    points: 1
+  - player: "Doug Moring"
+    points: 1
+  - player: "Shannon Schupbach"
+    points: 1
+  - player: "Jessica Badger"
+    points: 1
+  - player: "Luke Wesolowski"
+    points: 1
+  - player: "Thomas Elwood"
+    points: 1
+  - player: "Jackie Semko"
+    points: 1
+  - player: "Michael Scarpelli"
+    points: 1
+  - player: "Thorsten Sahlin"
+    points: 1
+  - player: "DJ Robinson"
+    points: 1

--- a/data/results/2025-lakeside-oh-national-tournaments.yaml
+++ b/data/results/2025-lakeside-oh-national-tournaments.yaml
@@ -1,0 +1,34 @@
+event: "Lakeside, OH National Tournaments"
+category: national
+year: 2025
+results:
+  - player: "Fabiola Camacho"
+    points: 20
+  - player: "John Windler"
+    points: 17
+  - player: "Erik Windler"
+    points: 17
+  - player: "Sammy Wachholz"
+    points: 13
+  - player: "Abby Manville"
+    points: 12
+  - player: "Natalie Gabrenya"
+    points: 7
+  - player: "Maggie Jones"
+    points: 6
+  - player: "Dana Rotz"
+    points: 5
+  - player: "Lauren Seesel"
+    points: 4
+  - player: "Sean Reddington"
+    points: 4
+  - player: "Al Manville"
+    points: 4
+  - player: "Steven Perry"
+    points: 2
+  - player: "Tyler Berry"
+    points: 2
+  - player: "John Allen"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2

--- a/data/results/2025-mirror-lake-championship.yaml
+++ b/data/results/2025-mirror-lake-championship.yaml
@@ -1,0 +1,120 @@
+event: "Mirror Lake Championship"
+category: championship
+year: 2025
+results:
+  - player: "Robert O'mahoney"
+    points: 17
+  - player: "Mark Malatt"
+    points: 11
+  - player: "Dave Berman"
+    points: 8
+  - player: "Sean Reddington"
+    points: 8
+  - player: "Paul Assad"
+    points: 6
+  - player: "Gabe Paul"
+    points: 6
+  - player: "Lauren Seesel"
+    points: 6
+  - player: "Teddy Wachholz"
+    points: 6
+  - player: "Jason Hiquet"
+    points: 6
+  - player: "Brandon V"
+    points: 6
+  - player: "Steven Perry"
+    points: 2
+  - player: "Tyler Berry"
+    points: 2
+  - player: "John Windler"
+    points: 2
+  - player: "Erik Windler"
+    points: 2
+  - player: "John Allen"
+    points: 2
+  - player: "Kate Fitzgerald"
+    points: 2
+  - player: "Fabiola Camacho"
+    points: 2
+  - player: "James Gallagher"
+    points: 2
+  - player: "Michael A Dritto"
+    points: 2
+  - player: "Natalie Gabrenya"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Jordon Novak"
+    points: 2
+  - player: "Rebecca Mendoza"
+    points: 2
+  - player: "Derek Falk"
+    points: 2
+  - player: "Dana Rotz"
+    points: 2
+  - player: "Abby Manville"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Karson Bodnovich"
+    points: 2
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 2
+  - player: "Jim Seesel"
+    points: 2
+  - player: "Kim Marek"
+    points: 2
+  - player: "August Etsch"
+    points: 2
+  - player: "Radhika Tandon"
+    points: 2
+  - player: "Samantha Gallagher"
+    points: 2
+  - player: "Daniel Love Jr"
+    points: 2
+  - player: "Emily Ellsworth"
+    points: 2
+  - player: "Josh Petras"
+    points: 2
+  - player: "Aaron Politsky"
+    points: 2
+  - player: "Jillian Tente"
+    points: 2
+  - player: "Jessica Badger"
+    points: 2
+  - player: "Connor Morehouse"
+    points: 2
+  - player: "Brian O'Connell"
+    points: 2
+  - player: "Michelle DiMaggio"
+    points: 2
+  - player: "Al Manville"
+    points: 2
+  - player: "Susan R"
+    points: 2
+  - player: "Anna Balchunas"
+    points: 2
+  - player: "Michael Scarpelli"
+    points: 2
+  - player: "Scott Montgomery"
+    points: 2
+  - player: "Alan Rosetti"
+    points: 2
+  - player: "Amelia Burger"
+    points: 2
+  - player: "Carlie DeMelo"
+    points: 2
+  - player: "George Eric Brown"
+    points: 2
+  - player: "Jonathan Schnapp"
+    points: 2
+  - player: "Josh Dulabaum"
+    points: 2
+  - player: "Michael Brady"
+    points: 2
+  - player: "Roy Wicklund"
+    points: 2
+  - player: "Stephanie Swain"
+    points: 2

--- a/data/results/2025-mirror-lake-championship.yaml
+++ b/data/results/2025-mirror-lake-championship.yaml
@@ -1,5 +1,5 @@
 event: "Mirror Lake Championship"
-category: championship
+category: other
 year: 2025
 results:
   - player: "Robert O'mahoney"

--- a/data/results/2025-st-pete-fl-national-tournament.yaml
+++ b/data/results/2025-st-pete-fl-national-tournament.yaml
@@ -1,0 +1,14 @@
+event: "St Pete, FL National Tournament"
+category: national
+year: 2025
+results:
+  - player: "Daniel Love Jr"
+    points: 6
+  - player: "Doug Moring"
+    points: 2
+  - player: "Aaron Politsky"
+    points: 2
+  - player: "Mark Malatt"
+    points: 1
+  - player: "Karson Bodnovich"
+    points: 1

--- a/data/results/2025-tangsgiving.yaml
+++ b/data/results/2025-tangsgiving.yaml
@@ -1,0 +1,128 @@
+event: "Tangsgiving"
+category: ilsa
+year: 2025
+results:
+  - player: "Paul Assad"
+    points: 19
+  - player: "Gabe Paul"
+    points: 13
+  - player: "James Gallagher"
+    points: 11
+  - player: "Kate Fitzgerald"
+    points: 9
+  - player: "Dave Berman"
+    points: 8
+  - player: "Matthew Miller"
+    points: 8
+  - player: "Joshua D Garrett"
+    points: 8
+  - player: "Diana Diaz"
+    points: 8
+  - player: "Steven Perry"
+    points: 6
+  - player: "John Allen"
+    points: 6
+  - player: "Lauren Seesel"
+    points: 6
+  - player: "Rebecca Mendoza"
+    points: 6
+  - player: "Mathew Savill"
+    points: 6
+  - player: "Adam Jamrozy"
+    points: 6
+  - player: "David Smith"
+    points: 6
+  - player: "Radhika Tandon"
+    points: 6
+  - player: "Tyler Berry"
+    points: 4
+  - player: "Erik Windler"
+    points: 4
+  - player: "Mark Malatt"
+    points: 4
+  - player: "Robert O'mahoney"
+    points: 4
+  - player: "Adam Rahmel"
+    points: 4
+  - player: "Natalie Gabrenya"
+    points: 4
+  - player: "Cody Uidl"
+    points: 4
+  - player: "Abby Manville"
+    points: 4
+  - player: "Teddy Wachholz"
+    points: 4
+  - player: "Jason Hiquet"
+    points: 4
+  - player: "Kevin Reedy"
+    points: 4
+  - player: "Maggie Jones"
+    points: 4
+  - player: "Tyler Janese"
+    points: 4
+  - player: "Thomas P Mulroe"
+    points: 4
+  - player: "John Bistolfo"
+    points: 4
+  - player: "John Windler"
+    points: 2
+  - player: "Joseph Brett Spangler"
+    points: 2
+  - player: "Maxwell Julius"
+    points: 2
+  - player: "Fabiola Camacho"
+    points: 2
+  - player: "Michael A Dritto"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Dana Rotz"
+    points: 2
+  - player: "Justin Latta"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Karson Bodnovich"
+    points: 2
+  - player: "Andrew Collier"
+    points: 2
+  - player: "Jen Walton"
+    points: 2
+  - player: "Matt Nakano"
+    points: 2
+  - player: "James Kessler"
+    points: 2
+  - player: "Samantha Gallagher"
+    points: 2
+  - player: "Emily Power"
+    points: 2
+  - player: "Laura Silverman"
+    points: 2
+  - player: "Andrew Seputis"
+    points: 2
+  - player: "Brandon V"
+    points: 2
+  - player: "Don Drake"
+    points: 2
+  - player: "Jillian Tente"
+    points: 2
+  - player: "Shannon Schupbach"
+    points: 2
+  - player: "Connor Morehouse"
+    points: 2
+  - player: "Magdalena Donnels"
+    points: 2
+  - player: "Susan R"
+    points: 2
+  - player: "Jackie Semko"
+    points: 2
+  - player: "Shannon McCarthy"
+    points: 2
+  - player: "Thorsten Sahlin"
+    points: 2
+  - player: "Cortney Norton"
+    points: 2
+  - player: "Dustin Kozal"
+    points: 2
+  - player: "Sam Passarelli"
+    points: 2

--- a/data/results/2025-tangsgiving.yaml
+++ b/data/results/2025-tangsgiving.yaml
@@ -1,5 +1,5 @@
 event: "Tangsgiving"
-category: ilsa
+category: other
 year: 2025
 results:
   - player: "Paul Assad"

--- a/data/results/2025-valentangs.yaml
+++ b/data/results/2025-valentangs.yaml
@@ -1,5 +1,5 @@
 event: "Valentangs"
-category: ilsa
+category: other
 year: 2025
 results:
   - player: "Tyler Berry"

--- a/data/results/2025-valentangs.yaml
+++ b/data/results/2025-valentangs.yaml
@@ -1,0 +1,114 @@
+event: "Valentangs"
+category: ilsa
+year: 2025
+results:
+  - player: "Tyler Berry"
+    points: 19
+  - player: "Jason Hiquet"
+    points: 13
+  - player: "Jordon Novak"
+    points: 11
+  - player: "Joseph Brett Spangler"
+    points: 9
+  - player: "Steven Perry"
+    points: 8
+  - player: "John Allen"
+    points: 8
+  - player: "Fabiola Camacho"
+    points: 8
+  - player: "Michael A Dritto"
+    points: 8
+  - player: "Erik Windler"
+    points: 6
+  - player: "Mark Malatt"
+    points: 6
+  - player: "Robert O'mahoney"
+    points: 6
+  - player: "Derek Falk"
+    points: 6
+  - player: "Karson Bodnovich"
+    points: 6
+  - player: "Joe Brennan"
+    points: 6
+  - player: "Matt Nakano"
+    points: 6
+  - player: "Kiernan Ambrose"
+    points: 6
+  - player: "Gabe Paul"
+    points: 4
+  - player: "Rebecca Mendoza"
+    points: 4
+  - player: "Teddy Wachholz"
+    points: 4
+  - player: "Adam Jamrozy"
+    points: 4
+  - player: "Andrew Collier"
+    points: 4
+  - player: "Jim Seesel"
+    points: 4
+  - player: "Kim Marek"
+    points: 4
+  - player: "Jaime Etsch"
+    points: 4
+  - player: "Doug Moring"
+    points: 4
+  - player: "Emily Ellsworth"
+    points: 4
+  - player: "Jillian Madden"
+    points: 4
+  - player: "John Seeder"
+    points: 4
+  - player: "John Windler"
+    points: 2
+  - player: "Dave Berman"
+    points: 2
+  - player: "Natalie Gabrenya"
+    points: 2
+  - player: "Sammy Wachholz"
+    points: 2
+  - player: "Cody Uidl"
+    points: 2
+  - player: "Lauren Seesel"
+    points: 2
+  - player: "Dana Rotz"
+    points: 2
+  - player: "Sean Reddington"
+    points: 2
+  - player: "Nick Haynes"
+    points: 2
+  - player: "David Smith"
+    points: 2
+  - player: "Rachel Reichman"
+    points: 2
+  - player: "Kevin Reedy"
+    points: 2
+  - player: "Joshua D Garrett"
+    points: 2
+  - player: "Radhika Tandon"
+    points: 2
+  - player: "Thomas P Mulroe"
+    points: 2
+  - player: "Willy Palivos"
+    points: 2
+  - player: "Brian DeMaio"
+    points: 2
+  - player: "Craig Kelbus"
+    points: 2
+  - player: "Josh Petras"
+    points: 2
+  - player: "Jillian Tente"
+    points: 2
+  - player: "Ashley De La Rosa"
+    points: 2
+  - player: "Connor Morehouse"
+    points: 2
+  - player: "Sam Boebel"
+    points: 2
+  - player: "Jessica Martens"
+    points: 2
+  - player: "Brendan McNulty"
+    points: 2
+  - player: "Cheryl Ziemba"
+    points: 2
+  - player: "Noelle Riese"
+    points: 2

--- a/data/results/2025-west-slide-story.yaml
+++ b/data/results/2025-west-slide-story.yaml
@@ -1,0 +1,100 @@
+event: "West Slide Story"
+category: ilsa
+year: 2025
+results:
+  - player: "Justin Latta"
+    points: 11
+  - player: "Amanda DavyRomano"
+    points: 11
+  - player: "Derek Falk"
+    points: 8
+  - player: "Andrew Abern"
+    points: 8
+  - player: "John Allen"
+    points: 6
+  - player: "Joseph Tijerina"
+    points: 6
+  - player: "Kate Fitzgerald"
+    points: 5
+  - player: "Maxwell Julius"
+    points: 5
+  - player: "Paul Assad"
+    points: 4
+  - player: "Dave Berman"
+    points: 4
+  - player: "Fabiola Camacho"
+    points: 4
+  - player: "Lauren Seesel"
+    points: 4
+  - player: "Abby Manville"
+    points: 4
+  - player: "Nick Haynes"
+    points: 4
+  - player: "Brian DeMaio"
+    points: 4
+  - player: "Tyler Berry"
+    points: 3
+  - player: "Natalie Gabrenya"
+    points: 3
+  - player: "Sean Reddington"
+    points: 3
+  - player: "Karson Bodnovich"
+    points: 3
+  - player: "David Smith"
+    points: 3
+  - player: "Jen Walton"
+    points: 3
+  - player: "Eric R Koch"
+    points: 3
+  - player: "Kiernan Ambrose"
+    points: 3
+  - player: "Laura Silverman"
+    points: 3
+  - player: "Emily Ellsworth"
+    points: 3
+  - player: "Ike Baya"
+    points: 3
+  - player: "Thomas Elwood"
+    points: 3
+  - player: "Mike Vehlewald"
+    points: 3
+  - player: "Timothy Hosty"
+    points: 3
+  - player: "Josh Brown"
+    points: 3
+  - player: "John Windler"
+    points: 1
+  - player: "Erik Windler"
+    points: 1
+  - player: "Mark Malatt"
+    points: 1
+  - player: "James Gallagher"
+    points: 1
+  - player: "Sammy Wachholz"
+    points: 1
+  - player: "Rebecca Mendoza"
+    points: 1
+  - player: "Jim Seesel"
+    points: 1
+  - player: "August Etsch"
+    points: 1
+  - player: "Matt Nakano"
+    points: 1
+  - player: "Samantha Gallagher"
+    points: 1
+  - player: "Emily Power"
+    points: 1
+  - player: "Andrew Seputis"
+    points: 1
+  - player: "Adam Vavrick"
+    points: 1
+  - player: "Magdalena Donnels"
+    points: 1
+  - player: "Steve Sobel"
+    points: 1
+  - player: "Zachariah Wilson"
+    points: 1
+  - player: "John Shaw"
+    points: 1
+  - player: "Manny Diaz"
+    points: 1

--- a/layouts/points/list.html
+++ b/layouts/points/list.html
@@ -160,8 +160,8 @@
                         {{ $pct := mul (div (mul . 1.0) $p.total) 100 }}
                         <div class="lb-strip-seg
                           {{ if eq $e.kind "national" }}bg-indigo-500
-                          {{ else if eq $e.kind "championship" }}bg-amber-500
                           {{ else if eq $e.kind "league" }}bg-emerald-500
+                          {{ else if eq $e.kind "other" }}bg-rose-500
                           {{ else }}bg-sky-500{{ end }}"
                           data-event="{{ $e.slug }}"
                           style="width:{{ $pct }}%"
@@ -198,8 +198,8 @@
                       <span class="relative w-24 h-1.5 rounded-full bg-gray-200 overflow-hidden flex-none">
                         <span class="absolute inset-y-0 left-0
                           {{ if eq $e.kind "national" }}bg-indigo-500
-                          {{ else if eq $e.kind "championship" }}bg-amber-500
                           {{ else if eq $e.kind "league" }}bg-emerald-500
+                          {{ else if eq $e.kind "other" }}bg-rose-500
                           {{ else }}bg-sky-500{{ end }}" style="width:{{ $pct }}%"></span>
                       </span>
                       <span class="tabular-nums text-sm font-semibold text-gray-900 w-7 text-right">{{ . }}</span>
@@ -220,10 +220,10 @@
 
       <div class="px-4 sm:px-5 py-3 bg-gray-50 border-t border-gray-200 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-600">
         <span class="font-semibold uppercase tracking-wider text-[10px] text-gray-500">Event types</span>
-        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-indigo-500"></span>Nationals</span>
-        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-amber-500"></span>Championship</span>
-        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-emerald-500"></span>Leagues</span>
-        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-sky-500"></span>ILSA</span>
+        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-indigo-500"></span>National Tournament</span>
+        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-emerald-500"></span>ILSA League</span>
+        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-sky-500"></span>ILSA Event</span>
+        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-full bg-rose-500"></span>Other Event</span>
         <span class="ml-auto text-gray-500 hidden sm:inline">Click any player to see their breakdown</span>
       </div>
     </section>
@@ -234,15 +234,15 @@
         <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500">Filter by event</h3>
         <button type="button" data-clear-filter id="lb-clear" class="hidden text-xs font-medium text-indigo-600 hover:text-indigo-800 no-underline">Clear ✕</button>
       </div>
-      {{ range $kind, $label := (dict "national" "National Tournaments" "championship" "Championships" "league" "Leagues" "ilsa" "ILSA Events") }}
+      {{ range $kind, $label := (dict "national" "National Tournament" "league" "ILSA League" "ilsa" "ILSA Event" "other" "Other Event") }}
         {{ $list := where $events "kind" $kind }}
         {{ if gt (len $list) 0 }}
           <div class="mb-5">
             <div class="flex items-center gap-2 mb-1.5">
               <span class="h-1.5 w-1.5 rounded-full
                 {{ if eq $kind "national" }}bg-indigo-500
-                {{ else if eq $kind "championship" }}bg-amber-500
                 {{ else if eq $kind "league" }}bg-emerald-500
+                {{ else if eq $kind "other" }}bg-rose-500
                 {{ else }}bg-sky-500{{ end }}"></span>
               <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">{{ $label }}</span>
             </div>
@@ -275,7 +275,7 @@
   var eventBySlug = {};
   events.forEach(function (e) { eventBySlug[e.slug] = e; });
 
-  var KIND_BG = { national: "bg-indigo-500", championship: "bg-amber-500", league: "bg-emerald-500", ilsa: "bg-sky-500" };
+  var KIND_BG = { national: "bg-indigo-500", league: "bg-emerald-500", ilsa: "bg-sky-500", other: "bg-rose-500" };
 
   var rowsEl   = document.getElementById("lb-rows");
   var rows     = rowsEl ? Array.prototype.slice.call(rowsEl.querySelectorAll(".lb-row")) : [];

--- a/layouts/points/list.html
+++ b/layouts/points/list.html
@@ -1,10 +1,8 @@
 {{ define "main" }}
 
-{{/* ─── ILSA Points page (redesigned) ─────────────────────────────────────
-     Same data source as before (CSV at .Params.google_doc), but rendered
-     as a vertical leaderboard with an expandable per-player breakdown and
-     a sticky "Filter by event" sidebar. Interactivity is vanilla JS;
-     the page works without it (filter UI gracefully no-ops).
+{{/* ─── ILSA Points page ────────────────────────────────────────────────────
+     Data is loaded from data/results/*.yaml files (one file per tournament).
+     Front matter `year` filters to a single season; omit for all-time.
 ─────────────────────────────────────────────────────────────────────────*/}}
 
 <h3 class="text-2xl font-extrabold text-gray-900 tracking-tight sm:text-3xl mt-6">State Points</h3>
@@ -31,51 +29,54 @@
 
 <h4 class="text-xl font-semibold text-gray-900 mt-8">{{ .Params.sub_title }}</h4>
 
-{{/* ─── Parse CSV ─── */}}
-{{ $url := .Params.google_doc }}
-{{ $csv := resources.GetRemote $url | transform.Unmarshal }}
+{{/* ─── Load & filter tournament data ─── */}}
+{{ $filterYear := .Params.year }}
 
-{{/* Header row → event metadata. Columns 0 and 1 are Name / Total. */}}
-{{ $header := index $csv 0 }}
+{{ $allTournaments := slice }}
+{{ range $key, $t := site.Data.results }}
+  {{ $allTournaments = $allTournaments | append (merge $t (dict "slug" $key)) }}
+{{ end }}
+
+{{ $tournaments := $allTournaments }}
+{{ if $filterYear }}
+  {{ $tournaments = where $allTournaments "year" $filterYear }}
+{{ end }}
+
+{{/* Sort events alphabetically by slug for stable sidebar ordering */}}
+{{ $tournaments = sort $tournaments "slug" "asc" }}
+
+{{/* ─── Build events list ─── */}}
 {{ $events := slice }}
-{{ range $i, $col := $header }}
-  {{ if gt $i 1 }}
-    {{ $kind := "ilsa" }}
-    {{ if or (in $col "National") (in $col "national") }}{{ $kind = "national" }}{{ end }}
-    {{ if in $col "League" }}{{ $kind = "league" }}{{ end }}
-    {{ if in $col "Championship" }}{{ $kind = "championship" }}{{ end }}
-    {{ $events = $events | append (dict
-        "idx"   $i
-        "name"  $col
-        "kind"  $kind
-        "slug"  (printf "e%d" $i)) }}
-  {{ end }}
+{{ range $t := $tournaments }}
+  {{ $events = $events | append (dict
+      "name" $t.event
+      "kind" $t.category
+      "slug" $t.slug) }}
 {{ end }}
 
-{{/* Build player rows (skip header + 0-point players). */}}
-{{ $players := slice }}
-{{ range $row_i, $row := $csv }}
-  {{ if and (ne $row_i 0) (ne (index $row 1) "0") (ne (index $row 1) "") (findRE "^[0-9]+$" (index $row 1)) }}
-    {{ $name  := index $row 0 }}
-    {{ $total := index $row 1 | int }}
-    {{ $bd := dict }}
-    {{ $count := 0 }}
-    {{ range $e := $events }}
-      {{ $cell := index $row $e.idx }}
-      {{ if and (ne $cell "") (ne $cell "0") (findRE "^[0-9]+$" $cell) }}
-        {{ $bd = merge $bd (dict $e.slug ($cell | int)) }}
-        {{ $count = add $count 1 }}
-      {{ end }}
+{{/* ─── Aggregate player data across all matching tournaments ─── */}}
+{{ $playerMap := dict }}
+{{ range $t := $tournaments }}
+  {{ range $r := $t.results }}
+    {{ $existing := index $playerMap $r.player }}
+    {{ if not $existing }}
+      {{ $existing = dict "name" $r.player "total" 0 "breakdown" (dict) "eventCount" 0 }}
     {{ end }}
-    {{ $players = $players | append (dict
-        "name"        $name
-        "total"       $total
-        "breakdown"   $bd
-        "eventCount"  $count) }}
+    {{ $playerMap = merge $playerMap (dict $r.player (dict
+        "name"       $r.player
+        "total"      (add $existing.total $r.points)
+        "breakdown"  (merge $existing.breakdown (dict $t.slug $r.points))
+        "eventCount" (add $existing.eventCount 1))) }}
   {{ end }}
 {{ end }}
 
-{{/* Event totals + participation (computed) */}}
+{{ $players := slice }}
+{{ range $name, $p := $playerMap }}
+  {{ $players = $players | append $p }}
+{{ end }}
+{{ $players = sort $players "total" "desc" }}
+
+{{/* ─── Event totals + participation ─── */}}
 {{ $eventStats := dict }}
 {{ range $e := $events }}
   {{ $sum := 0 }}{{ $part := 0 }}
@@ -88,9 +89,6 @@
   {{ $eventStats = merge $eventStats (dict $e.slug (dict "total" $sum "participants" $part)) }}
 {{ end }}
 
-{{/* Stable-sort players by total desc (Hugo's `sort` is stable on equal keys) */}}
-{{ $players = sort $players "total" "desc" }}
-
 {{ $isEmpty := eq (len $players) 0 }}
 
 <div id="ilsa-points" class="mt-5"
@@ -99,7 +97,7 @@
 
   {{ if $isEmpty }}
     <div class="bg-white rounded-xl ring-1 ring-gray-200 shadow-sm p-10 text-center">
-      <div class="mx-auto h-12 w-12 rounded-full bg-indigo-100 grid place-items-center text-indigo-600 font-bold">{{ substr .Params.sub_title 2 2 }}</div>
+      <div class="mx-auto h-12 w-12 rounded-full bg-indigo-100 grid place-items-center text-indigo-600 font-bold">{{ substr .Params.sub_title 0 2 }}</div>
       <p class="mt-3 text-sm font-medium text-gray-900">{{ .Params.sub_title }} hasn't started yet</p>
       <p class="mt-1 text-xs text-gray-500">Check back once the first events are scored.</p>
     </div>
@@ -255,7 +253,6 @@
                         class="lb-event w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-left transition hover:bg-gray-100 text-gray-800">
                   <span class="flex-1 truncate">{{ $e.name }}</span>
                   <span class="lb-event-part tabular-nums text-xs px-1.5 rounded bg-gray-100 text-gray-600">{{ $st.participants }}p</span>
-                  <span class="lb-event-total tabular-nums text-xs font-semibold w-9 text-right text-gray-900">{{ $st.total }}</span>
                 </button>
               {{ end }}
             </div>
@@ -301,7 +298,6 @@
     var chev = row.querySelector(".lb-chevron");
     btn.addEventListener("click", function () {
       var open = !det.classList.contains("hidden");
-      // close others (single-open)
       rows.forEach(function (r) {
         r.querySelector(".lb-detail").classList.add("hidden");
         var c = r.querySelector(".lb-chevron"); if (c) c.style.transform = "";
@@ -347,7 +343,6 @@
       return true;
     });
 
-    // sort
     filtered.sort(function (a, b) {
       if (state.filter) {
         var ab = (JSON.parse(a.dataset.bd)[state.filter] || 0);
@@ -360,7 +355,6 @@
       return (+b.dataset.total) - (+a.dataset.total);
     });
 
-    // re-attach + re-rank
     rows.forEach(function (r) { r.style.display = "none"; });
     var lastTotal = null, lastRank = 0;
     filtered.forEach(function (r, i) {
@@ -376,7 +370,6 @@
       rankEl.className = "lb-rank tabular-nums font-semibold text-sm " +
         (rank === 1 ? "text-amber-600" : rank <= 3 ? "text-indigo-700" : "text-gray-500");
 
-      // primary / secondary cells reflect filter mode
       var bd = JSON.parse(r.dataset.bd || "{}");
       var primaryEl = r.querySelector(".lb-primary");
       var primaryLabel = r.querySelector(".lb-primary-label");
@@ -395,7 +388,6 @@
         secondary.className = "lb-secondary text-xs text-gray-500 hidden sm:block text-right tabular-nums";
       }
 
-      // dim/highlight strip segments
       r.querySelectorAll(".lb-strip-seg").forEach(function (seg) {
         if (state.filter) {
           seg.style.opacity = (seg.dataset.event === state.filter) ? "1" : "0.22";
@@ -405,18 +397,14 @@
       });
     });
 
-    // sidebar active state
     document.querySelectorAll(".lb-event").forEach(function (btn) {
       var on = btn.getAttribute("data-event-pick") === state.filter;
       var part = btn.querySelector(".lb-event-part");
-      var tot  = btn.querySelector(".lb-event-total");
       btn.className = "lb-event w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-left transition " +
         (on ? "bg-indigo-600 text-white" : "hover:bg-gray-100 text-gray-800");
       if (part) part.className = "lb-event-part tabular-nums text-xs px-1.5 rounded " + (on ? "bg-indigo-500/60 text-white" : "bg-gray-100 text-gray-600");
-      if (tot)  tot.className  = "lb-event-total tabular-nums text-xs font-semibold w-9 text-right " + (on ? "text-white" : "text-gray-900");
     });
 
-    // banner + header
     if (state.filter) {
       var e = eventBySlug[state.filter];
       banner.classList.remove("hidden");
@@ -427,14 +415,11 @@
       if (clearBtn) clearBtn.classList.remove("hidden");
     } else {
       banner.classList.add("hidden");
-      title.textContent = (sub.dataset && sub.dataset.defaultTitle) || title.dataset.defaultTitle || title.textContent;
-      // restore defaults from cached
       title.textContent = title.dataset.defaultTitle;
       sub.textContent = sub.dataset.defaultSub;
       if (clearBtn) clearBtn.classList.add("hidden");
     }
 
-    // empty
     if (filtered.length === 0) {
       empty.classList.remove("hidden");
       empty.innerHTML = state.q
@@ -447,7 +432,6 @@
     }
   }
 
-  // cache defaults so we can restore on clear
   if (title) title.dataset.defaultTitle = title.textContent;
   if (sub)   sub.dataset.defaultSub   = sub.textContent;
 })();


### PR DESCRIPTION
## What this does

Replaces the live Google Sheets CSV fetch with a static YAML data store in `data/results/`. One file per tournament, named `{year}-{event-slug}.yaml`.

```yaml
# data/results/2025-chicago-il-national.yaml
event: "Chicago, IL National"
category: national
year: 2025
results:
  - player: "Steven Perry"
    points: 12
  - player: "Tyler Berry"
    points: 12
  ...
```

## Why

**For Jim (the data maintainer):**
- After each tournament, add one new file — no spreadsheet formulas to maintain, no risk of breaking totals
- The all-time leaderboard is computed automatically; no separate sheet to keep in sync
- Player name corrections are made in one place and propagate everywhere instantly

**For the site:**
- Event categories (`national`, `league`, `championship`, `ilsa`) are defined explicitly in the data rather than inferred from event name strings
- Full history is version-controlled — every change is auditable
- No runtime dependency on Google Sheets being available during builds

## What's included

- **57 YAML files** covering all historical events from 2022–2025, migrated from the existing Google Sheets
- Updated `layouts/points/list.html` — reads from `site.Data.results`, aggregates player totals and breakdowns at build time
- Updated `content/points/*.md` — replaced `google_doc` URL with a `year` integer param; all-time page has no year filter
- Removed the total-points column from the event sidebar per PR #129 feedback

## Adding a new tournament result

```yaml
# data/results/2026-mirror-lake-championship.yaml
event: "Mirror Lake Championship"
category: championship
year: 2026
results:
  - player: "Player Name"
    points: 10
```

Push the file, Netlify deploys — done.

## Open questions for Jim

1. Are the categories right? Current buckets: `national`, `league`, `championship`, `ilsa`. A few events like Valentangs, Jingle Biscuits, Ten(d) Off are currently tagged `ilsa` — is there a better label (e.g. `other`)?
2. Should we add a CMS interface so Jim can add results through a form instead of editing YAML directly? (Doable given we have Decap CMS in another branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)