### PR TITLE
feat: add /volunteers redirect to tournament bracket staff view

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,6 +24,11 @@
   status = 302
 
 [[redirects]]
+  from = "/volunteers"
+  to = "https://2026-chicago-national.netlify.app/?choose&staff"
+  status = 302
+
+[[redirects]]
   from = "/l/banner-join"
   to = "/join"
   status = 302


### PR DESCRIPTION
## Summary
- Adds a `/volunteers` redirect pointing to `https://2026-chicago-national.netlify.app/?choose&staff`, the same tournament bracket app `/standings` uses, with `?choose&staff` appended for the staff view.

## Test plan
- [x] Verify `illinoisshuffleboard.org/volunteers` redirects to the bracket app with the staff query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)