### PR TITLE
feat: add /scoreboard redirect to nationals scoreboard

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -69,6 +69,11 @@
   # now points to 2026 bracket
 
 [[redirects]]
+  from = "/scoreboard"
+  to = "https://2026-chicago-national.netlify.app/scoreboard"
+  status = 302
+
+[[redirects]]
   from = "/national"
   to = "https://lnk.bio/ILLINOISSHUFFLEBOARD"
   status = 302


### PR DESCRIPTION
## Summary
- Adds a `/scoreboard` short link redirecting to https://2026-chicago-national.netlify.app/scoreboard

## Test plan
- [ ] Verify `/scoreboard` redirects correctly once deployed to Netlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)