### PR TITLE
fix: use /staff path for volunteers redirect target

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,7 @@
 
 [[redirects]]
   from = "/volunteers"
-  to = "https://2026-chicago-national.netlify.app/?choose&staff"
+  to = "https://2026-chicago-national.netlify.app/staff"
   status = 302
 
 [[redirects]]


### PR DESCRIPTION
## Summary
- Changes the `/volunteers` redirect target from `https://2026-chicago-national.netlify.app/?choose&staff` to `https://2026-chicago-national.netlify.app/staff`, using the tournament bracket's `/staff` path instead of the `?staff` query param.

## Test plan
- [x] Confirm `/staff` is a valid route on the 2026 nationals tournament bracket site and lands on the staff view
- [ ] Verify `/volunteers` redirects correctly after Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)