### PR TITLE
chore: gitignore local config and add worktreeinclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .vscode/
 .DS_Store
 node_modules/
+/.claude/
+/.env
+/.netlify/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env
+.netlify


### PR DESCRIPTION
## Summary
- Ignore `.claude/`, `.env`, and `.netlify/` since they contain local machine/session config and secrets that shouldn't be committed
- Add `.worktreeinclude` listing `.env` and `.netlify` so those files are still carried into new worktrees (dev server and Netlify CLI need them), while leaving `.claude/` out since it holds worktree state itself

## Test plan
- [x] Confirmed `.netlify/state.json`, `.claude/`, and `.env` are no longer surfaced by `git status`